### PR TITLE
Build the landing/home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,18 +2,236 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="WorkInPrivate - Secure Private Work Environment" description="WorkInPrivate provides a secure, private work environment for professionals who value privacy and data protection.">
-  <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
-    <div class="max-w-4xl mx-auto text-center">
-      <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6">
-        Welcome to <span class="text-indigo-600">WorkInPrivate</span>
-      </h1>
-      <p class="text-xl text-gray-600 mb-8">
-        Your secure, private work environment for professionals who value privacy and data protection.
-      </p>
-      <div class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
-        Coming Soon
+<BaseLayout title="WorkInPrivate - AI Content Generation That Runs on YOUR Machine" description="WorkInPrivate is an AI-powered content generation tool that runs 100% locally using Ollama. No API costs, no cloud, complete privacy. 7 specialized modules for SEO, tech docs, academic, finance, healthcare, legal, and small business content.">
+
+  <!-- Hero Section -->
+  <section class="bg-gradient-to-br from-indigo-50 via-white to-indigo-50 py-20 sm:py-28">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-4xl mx-auto text-center">
+        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 leading-tight">
+          AI-Powered Content Generation That Runs on <span class="text-indigo-600">YOUR Machine</span>
+        </h1>
+        <p class="text-xl sm:text-2xl text-gray-600 mb-10 max-w-3xl mx-auto">
+          Generate SEO-optimized articles, technical docs, and specialized content using local LLMs. No API costs. No cloud. Complete privacy.
+        </p>
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a href="/pricing" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
+            View Pricing
+          </a>
+          <a href="#how-it-works" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg text-indigo-600 bg-white border-2 border-indigo-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors">
+            How It Works
+          </a>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
+
+  <!-- How It Works Section -->
+  <section id="how-it-works" class="py-20 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Get Started in 3 Simple Steps</h2>
+        <p class="text-lg text-gray-600 max-w-2xl mx-auto">Up and running in minutes. No accounts, no subscriptions, no cloud dependencies.</p>
+      </div>
+      <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8">
+        <!-- Step 1 -->
+        <div class="text-center">
+          <div class="w-16 h-16 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-5">1</div>
+          <h3 class="text-xl font-semibold text-gray-900 mb-3">Install Ollama</h3>
+          <p class="text-gray-600">Download and install Ollama, the free open-source engine that powers your local AI models.</p>
+        </div>
+        <!-- Step 2 -->
+        <div class="text-center">
+          <div class="w-16 h-16 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-5">2</div>
+          <h3 class="text-xl font-semibold text-gray-900 mb-3">Download WorkInPrivate</h3>
+          <p class="text-gray-600">Get the app for Windows, macOS, or Linux. Extract and run — no installation wizard needed.</p>
+        </div>
+        <!-- Step 3 -->
+        <div class="text-center">
+          <div class="w-16 h-16 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-5">3</div>
+          <h3 class="text-xl font-semibold text-gray-900 mb-3">Generate Content</h3>
+          <p class="text-gray-600">Choose a module, pick a topic, and let your local AI create professional content in seconds.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Features Grid -->
+  <section class="py-20 bg-gray-50">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Why WorkInPrivate?</h2>
+        <p class="text-lg text-gray-600 max-w-2xl mx-auto">Professional content generation without the compromises.</p>
+      </div>
+      <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        <!-- Feature 1 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-5">
+            <svg class="w-6 h-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">100% Local &amp; Private</h3>
+          <p class="text-gray-600">All processing happens on your machine. Your data never leaves your computer — ever.</p>
+        </div>
+        <!-- Feature 2 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-5">
+            <svg class="w-6 h-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Zero API Costs</h3>
+          <p class="text-gray-600">Uses free, open-source AI models via Ollama. No subscriptions, no per-token fees, no surprises.</p>
+        </div>
+        <!-- Feature 3 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-5">
+            <svg class="w-6 h-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Multi-Format Output</h3>
+          <p class="text-gray-600">Export your content as Markdown, plain text, HTML, or PDF — ready for any workflow.</p>
+        </div>
+        <!-- Feature 4 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-5">
+            <svg class="w-6 h-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">7 Specialized Modules</h3>
+          <p class="text-gray-600">Purpose-built modules for SEO, tech docs, academic, finance, healthcare, legal, and small business content.</p>
+        </div>
+        <!-- Feature 5 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-5">
+            <svg class="w-6 h-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Cross-Platform</h3>
+          <p class="text-gray-600">Runs on Windows, macOS, and Linux. Works wherever you do.</p>
+        </div>
+        <!-- Feature 6 -->
+        <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-100">
+          <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-5">
+            <svg class="w-6 h-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Smart Model Recommendations</h3>
+          <p class="text-gray-600">Automatically suggests the best AI model based on your system specs for optimal performance.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Module Showcase -->
+  <section class="py-20 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">7 Modules. One Toolkit.</h2>
+        <p class="text-lg text-gray-600 max-w-2xl mx-auto">Each module is fine-tuned for its domain, generating content that meets industry standards and expectations.</p>
+      </div>
+      <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <!-- SEO Writer -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all">
+          <div class="text-2xl mb-3">&#9997;&#65039;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">SEO Writer</h3>
+          <p class="text-gray-600 text-sm">Generate SEO-optimized blog articles with keyword research, meta descriptions, and proper heading structure.</p>
+        </div>
+        <!-- Tech Docs -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all">
+          <div class="text-2xl mb-3">&#128187;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Tech Docs</h3>
+          <p class="text-gray-600 text-sm">Create technical documentation from code repositories with clear explanations and API references.</p>
+        </div>
+        <!-- Academic -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all">
+          <div class="text-2xl mb-3">&#127891;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Academic</h3>
+          <p class="text-gray-600 text-sm">Generate academic papers and research articles with proper citations, abstracts, and scholarly formatting.</p>
+        </div>
+        <!-- Finance -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all">
+          <div class="text-2xl mb-3">&#128200;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Finance</h3>
+          <p class="text-gray-600 text-sm">Financial reports, market analysis, and investment content with appropriate disclaimers and data presentation.</p>
+        </div>
+        <!-- Healthcare -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all">
+          <div class="text-2xl mb-3">&#9877;&#65039;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Healthcare</h3>
+          <p class="text-gray-600 text-sm">Healthcare content generation with medical terminology, patient education materials, and compliance-aware formatting.</p>
+        </div>
+        <!-- Legal -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all">
+          <div class="text-2xl mb-3">&#9878;&#65039;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Legal</h3>
+          <p class="text-gray-600 text-sm">Legal documents, contracts, and compliance content with proper legal terminology and structure.</p>
+        </div>
+        <!-- Small Business -->
+        <div class="rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all sm:col-span-2 lg:col-span-1">
+          <div class="text-2xl mb-3">&#127970;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Small Business</h3>
+          <p class="text-gray-600 text-sm">Marketing copy, business plans, social media content, and operational documents tailored for small businesses.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Privacy / Trust Section -->
+  <section class="py-20 bg-indigo-600">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-4xl mx-auto text-center">
+        <h2 class="text-3xl sm:text-4xl font-bold text-white mb-6">Your Data. Your Machine. Your Rules.</h2>
+        <p class="text-xl text-indigo-100 mb-12 max-w-2xl mx-auto">WorkInPrivate was built from the ground up for people who take privacy seriously.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-8">
+          <div>
+            <div class="w-14 h-14 bg-indigo-500 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg class="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+            </div>
+            <h3 class="text-lg font-semibold text-white mb-2">Stays on Your Machine</h3>
+            <p class="text-indigo-200">All content generation happens locally. Nothing is sent to external servers.</p>
+          </div>
+          <div>
+            <div class="w-14 h-14 bg-indigo-500 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg class="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3" />
+              </svg>
+            </div>
+            <h3 class="text-lg font-semibold text-white mb-2">No Internet Required</h3>
+            <p class="text-indigo-200">Once models are downloaded, work completely offline. No connectivity needed.</p>
+          </div>
+          <div>
+            <div class="w-14 h-14 bg-indigo-500 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg class="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+              </svg>
+            </div>
+            <h3 class="text-lg font-semibold text-white mb-2">Zero Telemetry</h3>
+            <p class="text-indigo-200">No tracking, no analytics, no phone-home. What you create is yours alone.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final CTA Section -->
+  <section class="py-20 bg-gray-50">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-6">Ready to Own Your Content Pipeline?</h2>
+        <p class="text-xl text-gray-600 mb-10">Start generating professional content today — privately, locally, and on your terms.</p>
+        <a href="/pricing" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
+          Get WorkInPrivate
+        </a>
+      </div>
+    </div>
+  </section>
+
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Replaced placeholder home page with a full marketing landing page
- Added 6 sections: Hero with CTAs, How It Works (3-step guide), Features Grid (6 feature cards with SVG icons), Module Showcase (all 7 modules), Privacy/Trust section, and Final CTA
- Uses existing Tailwind/Astro patterns with indigo/gray color scheme

Closes #3

## Test plan
- [ ] Verify site builds without errors (`npm run build`)
- [ ] Check all 6 sections render correctly at desktop, tablet, and mobile widths
- [ ] Verify CTA links point to `/pricing`
- [ ] Verify "How It Works" anchor link scrolls correctly
- [ ] Check module cards display all 7 modules with descriptions
- [ ] Verify privacy section renders with white-on-indigo contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)