### PR TITLE
Build the pricing page

### DIFF
--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,0 +1,269 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Pricing - WorkInPrivate" description="Get WorkInPrivate starting at $29 for the base package with one module. Add specialized modules for $19 each. No subscriptions, no API costs — pay once, own it forever.">
+
+  <!-- Pricing Hero -->
+  <section class="bg-gradient-to-br from-indigo-50 via-white to-indigo-50 py-16 sm:py-20">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Simple, One-Time Pricing</h1>
+      <p class="text-xl text-gray-600 max-w-2xl mx-auto">Pay once, own it forever. No subscriptions, no API fees, no hidden costs.</p>
+    </div>
+  </section>
+
+  <!-- Base Package -->
+  <section class="py-16 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-lg mx-auto">
+        <div class="rounded-2xl border-2 border-indigo-600 shadow-xl overflow-hidden">
+          <div class="bg-indigo-600 px-8 py-4 text-center">
+            <span class="text-sm font-semibold text-indigo-100 uppercase tracking-wide">Most Popular</span>
+          </div>
+          <div class="px-8 py-10 text-center">
+            <h2 class="text-2xl font-bold text-gray-900 mb-2">Base Package</h2>
+            <p class="text-gray-600 mb-6">The app + 1 module of your choice</p>
+            <div class="mb-6">
+              <span class="text-5xl font-bold text-gray-900">$29</span>
+              <span class="text-gray-500 ml-2">one-time</span>
+            </div>
+            <ul class="text-left space-y-3 mb-8">
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <span class="text-gray-700">WorkInPrivate desktop app</span>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <span class="text-gray-700">1 module of your choice</span>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <span class="text-gray-700">Windows, macOS, and Linux</span>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <span class="text-gray-700">Multi-format output (MD, TXT, HTML, PDF)</span>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <span class="text-gray-700">100% local — no data leaves your machine</span>
+              </li>
+            </ul>
+            <a href="#" class="block w-full text-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
+              Buy Now
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Add-on Modules -->
+  <section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Add-on Modules</h2>
+        <p class="text-lg text-gray-600 max-w-2xl mx-auto">Expand your toolkit with specialized modules — <span class="font-semibold text-gray-900">$19 each</span>.</p>
+      </div>
+      <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+
+        <!-- SEO Writer -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col">
+          <div class="text-2xl mb-3">&#9997;&#65039;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">SEO Writer</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Generate SEO-optimized blog articles with keyword research, meta descriptions, and proper heading structure.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+        <!-- Tech Docs -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col">
+          <div class="text-2xl mb-3">&#128187;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Tech Docs</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Create technical documentation from code repositories with clear explanations and API references.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+        <!-- Academic -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col">
+          <div class="text-2xl mb-3">&#127891;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Academic</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Generate academic papers and research articles with proper citations, abstracts, and scholarly formatting.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+        <!-- Finance -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col">
+          <div class="text-2xl mb-3">&#128200;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Finance</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Financial reports, market analysis, and investment content with appropriate disclaimers and data presentation.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+        <!-- Healthcare -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col">
+          <div class="text-2xl mb-3">&#9877;&#65039;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Healthcare</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Healthcare content generation with medical terminology, patient education materials, and compliance-aware formatting.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+        <!-- Legal -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col">
+          <div class="text-2xl mb-3">&#9878;&#65039;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Legal</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Legal documents, contracts, and compliance content with proper legal terminology and structure.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+        <!-- Small Business -->
+        <div class="bg-white rounded-xl border border-gray-200 p-6 flex flex-col sm:col-span-2 lg:col-span-1">
+          <div class="text-2xl mb-3">&#127970;</div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Small Business</h3>
+          <p class="text-gray-600 text-sm flex-grow mb-5">Marketing copy, business plans, social media content, and operational documents tailored for small businesses.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-2xl font-bold text-gray-900">$19</span>
+            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+              Add Module
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- System Requirements -->
+  <section class="py-16 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">System Requirements</h2>
+          <p class="text-lg text-gray-600">WorkInPrivate runs on your hardware using Ollama for local AI inference.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <!-- Requirements -->
+          <div class="bg-gray-50 rounded-xl p-8">
+            <h3 class="text-lg font-semibold text-gray-900 mb-4">Hardware</h3>
+            <ul class="space-y-3">
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">RAM:</span>
+                  <span class="text-gray-600"> 8 GB minimum, 16 GB+ recommended</span>
+                </div>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">GPU:</span>
+                  <span class="text-gray-600"> Optional but recommended for faster generation</span>
+                </div>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">Storage:</span>
+                  <span class="text-gray-600"> 5 GB+ for app and AI models</span>
+                </div>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">Internet:</span>
+                  <span class="text-gray-600"> Only for initial model download</span>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <!-- Platform Availability -->
+          <div class="bg-gray-50 rounded-xl p-8">
+            <h3 class="text-lg font-semibold text-gray-900 mb-4">Platform Availability</h3>
+            <ul class="space-y-3">
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">Windows</span>
+                  <span class="text-gray-600"> — .exe (portable zip)</span>
+                </div>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">macOS</span>
+                  <span class="text-gray-600"> — .app (universal binary)</span>
+                </div>
+              </li>
+              <li class="flex items-start">
+                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                <div>
+                  <span class="font-medium text-gray-900">Linux</span>
+                  <span class="text-gray-600"> — .tar.gz</span>
+                </div>
+              </li>
+            </ul>
+            <div class="mt-6 p-4 bg-indigo-50 rounded-lg">
+              <p class="text-sm text-indigo-800">
+                <span class="font-semibold">Requires Ollama</span> — a free, open-source local AI runtime. WorkInPrivate will guide you through setup on first launch.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Created `/pricing` page with full pricing layout
- Base package card ($29) with feature checklist and "Buy Now" CTA (placeholder URL)
- 7 add-on module cards ($19 each) with descriptions and individual "Add Module" buttons (placeholder URLs)
- System requirements section (RAM, GPU, storage, internet needs)
- Platform availability section (Windows, macOS, Linux with file formats)
- Ollama dependency callout

Closes #4

## Test plan
- [ ] Verify site builds without errors (`npm run build`)
- [ ] Check base package card renders with $29 price, feature list, and CTA button
- [ ] Verify all 7 module cards display with correct names, descriptions, and $19 pricing
- [ ] Check system requirements and platform sections render correctly
- [ ] Test responsive layout at mobile, tablet, and desktop widths
- [ ] Verify "Buy Now" / "Add Module" buttons are present (placeholder `#` hrefs for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)