### PR TITLE
Build the FAQ page

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,0 +1,233 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="FAQ - WorkInPrivate" description="Frequently asked questions about WorkInPrivate — the AI-powered content generation tool that runs 100% locally on your machine.">
+
+  <!-- FAQ Hero -->
+  <section class="bg-gradient-to-br from-indigo-50 via-white to-indigo-50 py-16 sm:py-20">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Frequently Asked Questions</h1>
+      <p class="text-xl text-gray-600 max-w-2xl mx-auto">Everything you need to know about WorkInPrivate.</p>
+    </div>
+  </section>
+
+  <!-- FAQ Accordion -->
+  <section class="py-16 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto space-y-4">
+
+        <!-- Q1 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">What is WorkInPrivate?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">WorkInPrivate is an AI-powered content generation tool that runs 100% locally on your computer using Ollama. It generates SEO-optimized blog articles and specialized content across 7 professional modules — SEO Writer, Tech Docs, Academic, Finance, Healthcare, Legal, and Small Business. No data ever leaves your machine.</p>
+          </div>
+        </div>
+
+        <!-- Q2 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">What is Ollama and why is it needed?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">Ollama is a free, open-source AI model runtime that lets you run large language models locally on your computer. WorkInPrivate uses Ollama as its AI engine — this is what makes it possible to generate content without sending anything to the cloud. You can download Ollama for free at <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700 underline" target="_blank" rel="noopener noreferrer">ollama.com</a>. It takes about 2 minutes to install.</p>
+          </div>
+        </div>
+
+        <!-- Q3 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">What AI models are supported?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">WorkInPrivate supports any model available through Ollama, including Llama, Mistral, Gemma, Phi, and many more. The app includes a smart model recommender that suggests the best model for your hardware. Larger models (13B+ parameters) produce higher quality output, while smaller models (3B–7B) are faster on modest hardware. Models are downloaded once and cached locally.</p>
+          </div>
+        </div>
+
+        <!-- Q4 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">What are the system requirements?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <div class="text-gray-600 space-y-2">
+              <p>Minimum requirements:</p>
+              <ul class="list-disc list-inside space-y-1 ml-2">
+                <li><strong>RAM:</strong> 8 GB minimum, 16 GB+ recommended</li>
+                <li><strong>GPU:</strong> Optional but recommended for faster generation</li>
+                <li><strong>Storage:</strong> 5 GB+ for the app and AI models</li>
+                <li><strong>OS:</strong> Windows 10+, macOS 12+, or Linux</li>
+              </ul>
+              <p>A dedicated GPU (NVIDIA, AMD, or Apple Silicon) significantly speeds up content generation but is not required — WorkInPrivate runs on CPU as well.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Q5 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">How do I install and run WorkInPrivate?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <div class="text-gray-600 space-y-2">
+              <ol class="list-decimal list-inside space-y-1 ml-2">
+                <li>Install Ollama from <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700 underline" target="_blank" rel="noopener noreferrer">ollama.com</a></li>
+                <li>Download WorkInPrivate for your platform (Windows, macOS, or Linux)</li>
+                <li>Extract the archive to a folder</li>
+                <li>Run the application — a first-run setup wizard will guide you through model selection</li>
+              </ol>
+              <p>No installation wizard or admin rights needed. Just extract and run.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Q6 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">Can I use it for commercial purposes?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">Yes. Your WorkInPrivate license permits both personal and commercial use. Content you generate with the tool is yours to use however you see fit — publish it, sell it, or use it for client work. The license is per-user and non-transferable.</p>
+          </div>
+        </div>
+
+        <!-- Q7 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">What output formats are supported?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">WorkInPrivate supports four output formats: Markdown (.md), plain text (.txt), HTML (.html), and PDF (.pdf). All generated content is saved to an output folder, and you can choose your preferred format in the settings.</p>
+          </div>
+        </div>
+
+        <!-- Q8 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">Is my data private?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">Yes, 100%. WorkInPrivate runs entirely on your local machine. Your prompts, generated content, and all data stay on your computer. There is no telemetry, no analytics, and no phone-home functionality. The AI models themselves also run locally via Ollama — nothing is sent to external servers.</p>
+          </div>
+        </div>
+
+        <!-- Q9 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">How do updates work?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">When a new version of WorkInPrivate is available, you can download the latest release from your account. Simply replace your existing files with the updated version — your settings and output files are preserved. Updates are free for the version you purchased.</p>
+          </div>
+        </div>
+
+        <!-- Q10 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">What is the refund policy?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">We offer a 30-day money-back guarantee. If WorkInPrivate doesn't meet your expectations, contact us within 30 days of purchase for a full refund — no questions asked.</p>
+          </div>
+        </div>
+
+        <!-- Q11 -->
+        <div class="faq-item border border-gray-200 rounded-xl overflow-hidden">
+          <button class="faq-toggle w-full flex items-center justify-between px-6 py-5 text-left bg-white hover:bg-gray-50 transition-colors" aria-expanded="false">
+            <span class="text-lg font-semibold text-gray-900">Do I need an internet connection?</span>
+            <svg class="faq-icon w-5 h-5 text-gray-500 flex-shrink-0 ml-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="faq-content hidden px-6 pb-5">
+            <p class="text-gray-600">Only for the initial setup — downloading Ollama and your first AI model. After that, WorkInPrivate works completely offline. The optional web search feature (for sourcing research and citations) does require an internet connection, but it's entirely optional and can be disabled.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Still have questions?</h2>
+      <p class="text-lg text-gray-600 mb-8">Check out our pricing or get started today.</p>
+      <a href="/pricing" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
+        View Pricing
+      </a>
+    </div>
+  </section>
+
+</BaseLayout>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const items = document.querySelectorAll('.faq-item');
+
+    items.forEach((item) => {
+      const toggle = item.querySelector('.faq-toggle');
+      const content = item.querySelector('.faq-content');
+      const icon = item.querySelector('.faq-icon');
+
+      if (toggle && content && icon) {
+        toggle.addEventListener('click', () => {
+          const isOpen = !content.classList.contains('hidden');
+
+          // Close all other items
+          items.forEach((other) => {
+            if (other !== item) {
+              other.querySelector('.faq-content')?.classList.add('hidden');
+              other.querySelector('.faq-icon')?.classList.remove('rotate-180');
+              other.querySelector('.faq-toggle')?.setAttribute('aria-expanded', 'false');
+            }
+          });
+
+          // Toggle current item
+          content.classList.toggle('hidden');
+          icon.classList.toggle('rotate-180');
+          toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+        });
+      }
+    });
+  });
+</script>
+
+<style>
+  .faq-icon {
+    transition: transform 0.2s ease;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Created `/faq` page with all 11 questions from the issue
- Accordion/expandable style — click a question to reveal the answer, clicking another auto-collapses the previous one
- Answers sourced from WorkInPrivate README and repo docs for accuracy
- Includes link to ollama.com, system requirements details, and refund policy
- Bottom CTA section linking to pricing page

Closes #5

## Test plan
- [ ] Verify site builds without errors (`npm run build`)
- [ ] Check all 11 FAQ items render with correct questions
- [ ] Click each accordion item — answer should expand, previous should collapse
- [ ] Verify chevron icon rotates on expand/collapse
- [ ] Check `aria-expanded` attribute toggles correctly for accessibility
- [ ] Test responsive layout at mobile, tablet, and desktop widths
- [ ] Verify external links (ollama.com) open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)