### PR TITLE
Configure custom domain www.workinprivate.com

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,8 +5,7 @@ import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://wallco26.github.io',
-  base: '/workinprivate-site',
+  site: 'https://www.workinprivate.com',
   output: 'static',
   integrations: [tailwind(), sitemap()]
 });

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.workinprivate.com


### PR DESCRIPTION
## Summary
- Updated `astro.config.mjs`: changed `site` to `https://www.workinprivate.com` and removed the `/workinprivate-site` base path
- Added `public/CNAME` file with `www.workinprivate.com` for GitHub Pages custom domain
- Sitemap now generates with the correct domain

## DNS setup (already done in Namecheap)
| Type | Host | Value |
|------|------|-------|
| A | @ | 185.199.108.153 |
| A | @ | 185.199.109.153 |
| A | @ | 185.199.110.153 |
| A | @ | 185.199.111.153 |
| CNAME | www | wallco26.github.io |

## After merging
1. Go to **repo Settings → Pages → Custom domain** and enter `www.workinprivate.com`
2. Check **Enforce HTTPS** once the DNS propagates and the certificate is provisioned (may take a few minutes)

## Test plan
- [ ] Verify site builds without errors
- [ ] Confirm CNAME file appears in `dist/` output
- [ ] Confirm sitemap references `https://www.workinprivate.com`
- [ ] After merge + DNS propagation, verify `https://www.workinprivate.com` loads the site
- [ ] Verify `https://workinprivate.com` redirects to `www`

🤖 Generated with [Claude Code](https://claude.com/claude-code)