### PR TITLE
Set up Stripe Payment Links and checkout flow

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -1,0 +1,180 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Download WorkInPrivate" description="Thank you for your purchase! Download WorkInPrivate for Windows, macOS, or Linux.">
+
+  <!-- Thank You Hero -->
+  <section class="bg-gradient-to-br from-indigo-50 via-white to-indigo-50 py-16 sm:py-20">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <div class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
+        <svg class="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+      <h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Thank You for Your Purchase!</h1>
+      <p class="text-xl text-gray-600 max-w-2xl mx-auto">Your download is ready. Choose your platform below to get started.</p>
+    </div>
+  </section>
+
+  <!-- Download Buttons -->
+  <section class="py-16 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-4xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+
+          <!-- Windows -->
+          <div id="download-windows" class="download-card rounded-2xl border-2 border-gray-200 p-8 text-center hover:border-indigo-300 hover:shadow-lg transition-all">
+            <div class="mb-4">
+              <svg class="w-12 h-12 mx-auto text-gray-700" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/>
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold text-gray-900 mb-2">Windows</h3>
+            <p class="text-sm text-gray-500 mb-5">.exe (portable zip)</p>
+            <!-- TODO: Replace with actual download URL for Windows build -->
+            <a href="#download-windows-zip" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Download for Windows
+            </a>
+          </div>
+
+          <!-- macOS -->
+          <div id="download-macos" class="download-card rounded-2xl border-2 border-gray-200 p-8 text-center hover:border-indigo-300 hover:shadow-lg transition-all">
+            <div class="mb-4">
+              <svg class="w-12 h-12 mx-auto text-gray-700" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold text-gray-900 mb-2">macOS</h3>
+            <p class="text-sm text-gray-500 mb-5">.app (universal binary)</p>
+            <!-- TODO: Replace with actual download URL for macOS build -->
+            <a href="#download-macos-zip" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Download for macOS
+            </a>
+          </div>
+
+          <!-- Linux -->
+          <div id="download-linux" class="download-card rounded-2xl border-2 border-gray-200 p-8 text-center hover:border-indigo-300 hover:shadow-lg transition-all">
+            <div class="mb-4">
+              <svg class="w-12 h-12 mx-auto text-gray-700" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.368 1.884 1.43.868.065 1.571-.39 1.984-.819.24-.25.44-.53.27-.735-.19-.09-.38-.177-.578-.258a.188.188 0 00-.04-.01c-.15-.06-.22-.1-.33-.2-.02-.01-.04-.04-.07-.07-.03-.05-.08-.09-.12-.15-.08-.11-.16-.27-.22-.46-.2-.6-.18-1.37-.18-2.13 0-.42.02-.85-.02-1.28-.04-.38-.14-.77-.32-1.14-.18-.37-.4-.7-.66-1-.23-.24-.48-.44-.72-.64-.16-.12-.22-.28-.28-.48-.05-.2-.08-.42-.12-.62-.02-.14-.04-.28-.06-.4-.02-.1-.04-.22-.1-.38-.14-.4-.48-.46-.6-.72-.02-.04-.02-.1-.02-.16 0-.12.04-.24.04-.36.04-.4-.08-.78-.34-1.08-.2-.24-.5-.38-.78-.46.38-.7.64-1.48.76-2.3.14-.94.12-1.92-.08-2.88-.1-.48-.26-.94-.48-1.38-.56-1.12-1.36-2.02-2.36-2.68C14.26.58 13.38.14 12.5.02zm-.504.94c.156 0 .31.012.47.036.934.144 1.698.536 2.328 1.096.658.58 1.18 1.306 1.544 2.098.178.4.302.82.384 1.254.168.86.178 1.74.052 2.582-.118.792-.362 1.508-.678 2.14-.028.052-.058.102-.086.154a.94.94 0 00-.134-.006h-.002c-.468 0-.91.192-1.196.53-.28.328-.414.764-.394 1.194 0 .04-.004.06-.004.1-.012.19-.03.38.012.59.078.42.238.78.476 1.08-.05.06-.1.12-.16.18l-.08.1c-.24.28-.46.58-.64.9-.18.32-.3.68-.34 1.04-.04.36-.04.72-.02 1.08 0 .16 0 .32-.02.48a2.63 2.63 0 01-.1.48c-.2.64 0 1.22.2 1.78.04.1.08.2.14.32-.44.2-.72.6-.94.96-.2.3-.38.66-.62.88l-.04.04c-.08.06-.16.06-.28.08h-.02c-.26.04-.52.1-.78.2-.48.18-.94.48-1.18 1.08-.12.28-.12.58-.04.84-.72-.26-1.48-.34-2.06-.3-.22 0-.4.06-.58.16-.14.1-.2.2-.28.4-.14.32-.04.7.22 1.04.26.32.68.56 1.16.72-.62-.04-1.1-.2-1.36-.46-.2-.2-.28-.46-.1-.94.16-.46.02-.68-.24-1.22-.08-.16-.14-.32-.16-.52-.02-.14.02-.36.08-.56.1-.36.34-.72.66-1.04.08-.08.18-.16.28-.22.2-.14.4-.28.54-.46.18-.2.32-.44.48-.74.1-.2.16-.42.18-.64a4.27 4.27 0 00-.02-.78c-.02-.2-.02-.38 0-.56.02-.16.04-.3.08-.44l.02-.08c.08-.26.22-.46.46-.66.24-.22.54-.4.84-.58.56-.32 1.14-.58 1.58-.96.48-.4.82-.92 1.02-1.5l.02-.04"/>
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold text-gray-900 mb-2">Linux</h3>
+            <p class="text-sm text-gray-500 mb-5">.tar.gz</p>
+            <!-- TODO: Replace with actual download URL for Linux build -->
+            <a href="#download-linux-targz" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+              <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Download for Linux
+            </a>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Getting Started -->
+  <section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-gray-900 mb-8 text-center">Getting Started</h2>
+        <div class="space-y-6">
+
+          <!-- Step 1 -->
+          <div class="flex items-start gap-4">
+            <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">1</div>
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 mb-1">Install Ollama</h3>
+              <p class="text-gray-600">Download and install Ollama from <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700 underline" target="_blank" rel="noopener noreferrer">ollama.com</a>. It's free and takes about 2 minutes. Ollama is the AI engine that powers WorkInPrivate's local content generation.</p>
+            </div>
+          </div>
+
+          <!-- Step 2 -->
+          <div class="flex items-start gap-4">
+            <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">2</div>
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 mb-1">Extract the Archive</h3>
+              <p class="text-gray-600">Unzip (Windows/macOS) or extract (Linux) the downloaded archive to a folder of your choice. No installer needed — it's fully portable.</p>
+            </div>
+          </div>
+
+          <!-- Step 3 -->
+          <div class="flex items-start gap-4">
+            <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">3</div>
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 mb-1">Run WorkInPrivate</h3>
+              <p class="text-gray-600">Launch the application. On first run, a setup wizard will check your system, recommend an AI model based on your hardware, and guide you through downloading it.</p>
+            </div>
+          </div>
+
+          <!-- Step 4 -->
+          <div class="flex items-start gap-4">
+            <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">4</div>
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 mb-1">Generate Content</h3>
+              <p class="text-gray-600">Choose a module, enter a topic, and let your local AI create professional content. Output is saved to the <code class="bg-gray-100 px-1.5 py-0.5 rounded text-sm">output</code> folder in your preferred format (Markdown, Text, HTML, or PDF).</p>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Help Links -->
+  <section class="py-12 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-2xl mx-auto text-center">
+        <p class="text-gray-600 mb-4">Need help? Check out our resources:</p>
+        <div class="flex flex-wrap justify-center gap-4">
+          <a href="/faq" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            FAQ
+          </a>
+          <a href="https://github.com/wallco26/workinprivate" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors" target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</BaseLayout>
+
+<script>
+  // Auto-highlight the download card matching the user's OS
+  document.addEventListener('DOMContentLoaded', () => {
+    const ua = navigator.userAgent.toLowerCase();
+    let detectedOS = '';
+
+    if (ua.includes('win')) {
+      detectedOS = 'windows';
+    } else if (ua.includes('mac')) {
+      detectedOS = 'macos';
+    } else if (ua.includes('linux')) {
+      detectedOS = 'linux';
+    }
+
+    if (detectedOS) {
+      const card = document.getElementById(`download-${detectedOS}`);
+      if (card) {
+        card.classList.remove('border-gray-200');
+        card.classList.add('border-indigo-600', 'shadow-lg', 'ring-2', 'ring-indigo-100');
+
+        // Add "Detected" badge
+        const badge = document.createElement('span');
+        badge.className = 'inline-block bg-indigo-100 text-indigo-700 text-xs font-semibold px-2.5 py-1 rounded-full mb-3';
+        badge.textContent = 'Detected for your system';
+        card.insertBefore(badge, card.firstChild);
+      }
+    }
+  });
+</script>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -59,7 +59,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 <span class="text-gray-700">100% local — no data leaves your machine</span>
               </li>
             </ul>
-            <a href="#" class="block w-full text-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
+            <!-- TODO: Replace with Stripe Payment Link for Base Package ($29) -->
+            <a href="#stripe-base-package" class="block w-full text-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
               Buy Now
             </a>
           </div>
@@ -84,7 +85,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Generate SEO-optimized blog articles with keyword research, meta descriptions, and proper heading structure.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for SEO Writer module ($19) -->
+            <a href="#stripe-seo-writer" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -97,7 +99,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Create technical documentation from code repositories with clear explanations and API references.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for Tech Docs module ($19) -->
+            <a href="#stripe-tech-docs" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -110,7 +113,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Generate academic papers and research articles with proper citations, abstracts, and scholarly formatting.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for Academic module ($19) -->
+            <a href="#stripe-academic" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -123,7 +127,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Financial reports, market analysis, and investment content with appropriate disclaimers and data presentation.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for Finance module ($19) -->
+            <a href="#stripe-finance" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -136,7 +141,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Healthcare content generation with medical terminology, patient education materials, and compliance-aware formatting.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for Healthcare module ($19) -->
+            <a href="#stripe-healthcare" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -149,7 +155,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Legal documents, contracts, and compliance content with proper legal terminology and structure.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for Legal module ($19) -->
+            <a href="#stripe-legal" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -162,7 +169,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Marketing copy, business plans, social media content, and operational documents tailored for small businesses.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <a href="#" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <!-- TODO: Replace with Stripe Payment Link for Small Business module ($19) -->
+            <a href="#stripe-small-business" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>


### PR DESCRIPTION
## Summary
- **Pricing page updated** — replaced all `href="#"` with named placeholder anchors (`#stripe-base-package`, `#stripe-seo-writer`, etc.) with `<!-- TODO -->` comments marking each one for easy Stripe Payment Link replacement
- **Download page created** (`/download`) — post-purchase success page with:
  - Thank-you hero with green checkmark
  - 3 platform download cards (Windows .exe, macOS .app, Linux .tar.gz) with placeholder download URLs
  - **OS auto-detection** — JavaScript detects the visitor's OS and highlights the matching download card with a "Detected for your system" badge
  - 4-step getting started guide (Install Ollama → Extract → Run → Generate)
  - Help links to FAQ and GitHub

### Placeholder URLs to replace later
**Pricing page** (8 Stripe Payment Links):
- `#stripe-base-package` — Base Package ($29)
- `#stripe-seo-writer` — SEO Writer ($19)
- `#stripe-tech-docs` — Tech Docs ($19)
- `#stripe-academic` — Academic ($19)
- `#stripe-finance` — Finance ($19)
- `#stripe-healthcare` — Healthcare ($19)
- `#stripe-legal` — Legal ($19)
- `#stripe-small-business` — Small Business ($19)

**Download page** (3 download URLs):
- `#download-windows-zip`
- `#download-macos-zip`
- `#download-linux-targz`

All Stripe Payment Links should have their success redirect URL set to `https://www.workinprivate.com/download`.

Closes #7

## Test plan
- [ ] Verify site builds without errors (`npm run build` — 7 pages)
- [ ] Check pricing page has TODO comments on all 8 buy/add buttons
- [ ] Check `/download` renders thank-you message and 3 platform cards
- [ ] Verify OS detection highlights the correct card (test on different browsers/UA strings)
- [ ] Verify getting started steps render correctly
- [ ] Verify FAQ and GitHub help links work
- [ ] Test responsive layout at mobile, tablet, and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)