### PR TITLE
Add Stripe test mode Payment Links to pricing page

### DIFF
--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -59,8 +59,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 <span class="text-gray-700">100% local — no data leaves your machine</span>
               </li>
             </ul>
-            <!-- TODO: Replace with Stripe Payment Link for Base Package ($29) -->
-            <a href="#stripe-base-package" class="block w-full text-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
+            <a href="https://buy.stripe.com/test_9B6bJ05et2aW1aD1eeco000" class="block w-full text-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
               Buy Now
             </a>
           </div>
@@ -85,8 +84,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Generate SEO-optimized blog articles with keyword research, meta descriptions, and proper heading structure.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for SEO Writer module ($19) -->
-            <a href="#stripe-seo-writer" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_5kQaEW6ixdTE1aD0aaco004" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -99,8 +97,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Create technical documentation from code repositories with clear explanations and API references.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for Tech Docs module ($19) -->
-            <a href="#stripe-tech-docs" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_eVq00ifT75n8aLdf54co007" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -113,8 +110,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Generate academic papers and research articles with proper citations, abstracts, and scholarly formatting.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for Academic module ($19) -->
-            <a href="#stripe-academic" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_00weVcgXb2aW6uX4qqco005" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -127,8 +123,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Financial reports, market analysis, and investment content with appropriate disclaimers and data presentation.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for Finance module ($19) -->
-            <a href="#stripe-finance" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_6oUaEW22hbLwcTl5uuco006" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -141,8 +136,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Healthcare content generation with medical terminology, patient education materials, and compliance-aware formatting.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for Healthcare module ($19) -->
-            <a href="#stripe-healthcare" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_6oU00ieP38zk8D5f54co003" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -155,8 +149,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Legal documents, contracts, and compliance content with proper legal terminology and structure.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for Legal module ($19) -->
-            <a href="#stripe-legal" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_14A9AS22h4j4aLd6yyco002" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>
@@ -169,8 +162,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <p class="text-gray-600 text-sm flex-grow mb-5">Marketing copy, business plans, social media content, and operational documents tailored for small businesses.</p>
           <div class="flex items-center justify-between">
             <span class="text-2xl font-bold text-gray-900">$19</span>
-            <!-- TODO: Replace with Stripe Payment Link for Small Business module ($19) -->
-            <a href="#stripe-small-business" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
+            <a href="https://buy.stripe.com/test_fZucN4ayNbLwcTlcWWco001" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-indigo-600 border-2 border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 transition-colors">
               Add Module
             </a>
           </div>


### PR DESCRIPTION
## Summary
- Replaced all 8 placeholder `#stripe-*` hrefs with real Stripe test mode Payment Link URLs
- Removed all `<!-- TODO -->` comments from pricing page
- All URLs are test mode (`/test_`) — will need to be replaced with live URLs when going live

### URL mapping
| Product | Stripe Link |
|---|---|
| Base Package ($29) | `https://buy.stripe.com/test_9B6bJ05et2aW1aD1eeco000` |
| SEO Writer ($19) | `https://buy.stripe.com/test_5kQaEW6ixdTE1aD0aaco004` |
| Tech Docs ($19) | `https://buy.stripe.com/test_eVq00ifT75n8aLdf54co007` |
| Academic ($19) | `https://buy.stripe.com/test_00weVcgXb2aW6uX4qqco005` |
| Finance ($19) | `https://buy.stripe.com/test_6oUaEW22hbLwcTl5uuco006` |
| Healthcare ($19) | `https://buy.stripe.com/test_6oU00ieP38zk8D5f54co003` |
| Legal ($19) | `https://buy.stripe.com/test_14A9AS22h4j4aLd6yyco002` |
| Small Business ($19) | `https://buy.stripe.com/test_fZucN4ayNbLwcTlcWWco001` |

Closes #18

## Test plan
- [ ] Verify site builds without errors
- [ ] Confirm no `#stripe-*` placeholders or `TODO` comments remain in `pricing.astro`
- [ ] Click each "Buy Now" / "Add Module" button — should open Stripe test checkout
- [ ] Complete a test purchase using card `4242 4242 4242 4242` and verify redirect to `/download`
- [ ] Verify at least one add-on module link opens the correct product checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)