### PR TITLE
Fix Ollama instructions and wire up download URLs

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -32,12 +32,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-2">Windows</h3>
             <p class="text-sm text-gray-500 mb-5">.exe (portable zip)</p>
-            <!-- TODO: Replace with actual download URL for Windows build -->
-            <a href="#download-windows-zip" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+            <!-- TODO: Replace with actual download URL when Windows build is available -->
+            <a href="#" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-gray-400 cursor-not-allowed">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
-              Download for Windows
+              Coming Soon
             </a>
           </div>
 
@@ -50,12 +50,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-2">macOS</h3>
             <p class="text-sm text-gray-500 mb-5">.app (universal binary)</p>
-            <!-- TODO: Replace with actual download URL for macOS build -->
-            <a href="#download-macos-zip" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+            <!-- TODO: Replace with actual download URL when macOS build is available -->
+            <a href="#" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-gray-400 cursor-not-allowed">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
-              Download for macOS
+              Coming Soon
             </a>
           </div>
 
@@ -68,8 +68,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-2">Linux</h3>
             <p class="text-sm text-gray-500 mb-5">.tar.gz</p>
-            <!-- TODO: Replace with actual download URL for Linux build -->
-            <a href="#download-linux-targz" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+            <a href="https://github.com/wallco26/workinprivate/releases/download/v1.0.0/WorkInPrivate-Linux.tar.gz" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
@@ -93,8 +92,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <div class="flex items-start gap-4">
             <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">1</div>
             <div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-1">Install Ollama</h3>
-              <p class="text-gray-600">Download and install Ollama from <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700 underline" target="_blank" rel="noopener noreferrer">ollama.com</a>. It's free and takes about 2 minutes. Ollama is the AI engine that powers WorkInPrivate's local content generation.</p>
+              <h3 class="text-lg font-semibold text-gray-900 mb-1">Extract the Archive</h3>
+              <p class="text-gray-600">Unzip (Windows/macOS) or extract (Linux) the downloaded archive to a folder of your choice. No installer needed — it's fully portable.</p>
             </div>
           </div>
 
@@ -102,23 +101,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <div class="flex items-start gap-4">
             <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">2</div>
             <div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-1">Extract the Archive</h3>
-              <p class="text-gray-600">Unzip (Windows/macOS) or extract (Linux) the downloaded archive to a folder of your choice. No installer needed — it's fully portable.</p>
+              <h3 class="text-lg font-semibold text-gray-900 mb-1">Run WorkInPrivate</h3>
+              <p class="text-gray-600">Launch the application. On first run, a setup wizard will check your system, install Ollama automatically if needed, recommend an AI model based on your hardware, and guide you through downloading it.</p>
             </div>
           </div>
 
           <!-- Step 3 -->
           <div class="flex items-start gap-4">
             <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">3</div>
-            <div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-1">Run WorkInPrivate</h3>
-              <p class="text-gray-600">Launch the application. On first run, a setup wizard will check your system, recommend an AI model based on your hardware, and guide you through downloading it.</p>
-            </div>
-          </div>
-
-          <!-- Step 4 -->
-          <div class="flex items-start gap-4">
-            <div class="w-10 h-10 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-lg font-bold flex-shrink-0">4</div>
             <div>
               <h3 class="text-lg font-semibold text-gray-900 mb-1">Generate Content</h3>
               <p class="text-gray-600">Choose a module, enter a topic, and let your local AI create professional content. Output is saved to the <code class="bg-gray-100 px-1.5 py-0.5 rounded text-sm">output</code> folder in your preferred format (Markdown, Text, HTML, or PDF).</p>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -39,7 +39,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </svg>
           </button>
           <div class="faq-content hidden px-6 pb-5">
-            <p class="text-gray-600">Ollama is a free, open-source AI model runtime that lets you run large language models locally on your computer. WorkInPrivate uses Ollama as its AI engine — this is what makes it possible to generate content without sending anything to the cloud. You can download Ollama for free at <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700 underline" target="_blank" rel="noopener noreferrer">ollama.com</a>. It takes about 2 minutes to install.</p>
+            <p class="text-gray-600">Ollama is a free, open-source AI model runtime that lets you run large language models locally on your computer. WorkInPrivate uses Ollama as its AI engine — this is what makes it possible to generate content without sending anything to the cloud. WorkInPrivate automatically installs Ollama for you on first launch if it's not already on your system, so there's nothing extra to set up.</p>
           </div>
         </div>
 
@@ -89,12 +89,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <div class="faq-content hidden px-6 pb-5">
             <div class="text-gray-600 space-y-2">
               <ol class="list-decimal list-inside space-y-1 ml-2">
-                <li>Install Ollama from <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700 underline" target="_blank" rel="noopener noreferrer">ollama.com</a></li>
                 <li>Download WorkInPrivate for your platform (Windows, macOS, or Linux)</li>
                 <li>Extract the archive to a folder</li>
-                <li>Run the application — a first-run setup wizard will guide you through model selection</li>
+                <li>Run the application — on first launch, Ollama is installed automatically if needed, and a setup wizard guides you through model selection</li>
               </ol>
-              <p>No installation wizard or admin rights needed. Just extract and run.</p>
+              <p>No separate installations or admin rights needed. Just extract and run.</p>
             </div>
           </div>
         </div>
@@ -173,7 +172,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </svg>
           </button>
           <div class="faq-content hidden px-6 pb-5">
-            <p class="text-gray-600">Only for the initial setup — downloading Ollama and your first AI model. After that, WorkInPrivate works completely offline. The optional web search feature (for sourcing research and citations) does require an internet connection, but it's entirely optional and can be disabled.</p>
+            <p class="text-gray-600">Only for the initial setup — WorkInPrivate automatically installs Ollama and downloads your first AI model, which requires an internet connection. After that, it works completely offline. The optional web search feature (for sourcing research and citations) does require an internet connection, but it's entirely optional and can be disabled.</p>
           </div>
         </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,14 +37,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <!-- Step 1 -->
         <div class="text-center">
           <div class="w-16 h-16 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-5">1</div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-3">Install Ollama</h3>
-          <p class="text-gray-600">Download and install Ollama, the free open-source engine that powers your local AI models.</p>
+          <h3 class="text-xl font-semibold text-gray-900 mb-3">Download WorkInPrivate</h3>
+          <p class="text-gray-600">Get the app for Windows, macOS, or Linux. Extract and run — no installation wizard needed.</p>
         </div>
         <!-- Step 2 -->
         <div class="text-center">
           <div class="w-16 h-16 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-5">2</div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-3">Download WorkInPrivate</h3>
-          <p class="text-gray-600">Get the app for Windows, macOS, or Linux. Extract and run — no installation wizard needed.</p>
+          <h3 class="text-xl font-semibold text-gray-900 mb-3">Run the Setup Wizard</h3>
+          <p class="text-gray-600">On first launch, WorkInPrivate installs Ollama automatically and recommends the best AI model for your system.</p>
         </div>
         <!-- Step 3 -->
         <div class="text-center">


### PR DESCRIPTION
## Summary
Ollama is auto-installed by WorkInPrivate on first launch — users don't need to install it separately. This PR fixes all pages that incorrectly listed "Install Ollama" as a manual step.

### Changes across 3 files:

**`download.astro`**
- Reduced getting started from 4 steps to 3 (Extract → Run → Generate)
- Step 2 now mentions Ollama is installed automatically on first launch
- Linux download button wired to GitHub Release v1.0.0: `WorkInPrivate-Linux.tar.gz`
- Windows and macOS buttons changed to "Coming Soon" (grayed out) until those builds are available

**`index.astro`**
- "How It Works" steps updated: Download → Run Setup Wizard → Generate
- Step 2 explains Ollama auto-install and model recommendation

**`faq.astro`**
- "What is Ollama" answer updated — mentions auto-install, removed manual download instructions
- "How do I install" answer updated — removed Ollama step, now 3 steps
- "Do I need internet" answer updated — clarifies Ollama is installed automatically

### Also done
- Created GitHub Release v1.0.0 in the workinprivate repo with the Linux build: https://github.com/wallco26/workinprivate/releases/tag/v1.0.0

## Test plan
- [ ] Verify site builds without errors
- [ ] Check landing page "How It Works" shows 3 steps without manual Ollama install
- [ ] Check download page shows 3 getting started steps
- [ ] Verify Linux download button links to the GitHub Release asset
- [ ] Verify Windows and macOS buttons show "Coming Soon" and are grayed out
- [ ] Check FAQ answers for Ollama, install, and internet questions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)