### PR TITLE
Redesign hero section with app mockup and direct purchase CTA

### DIFF
--- a/src/components/AppMockup.astro
+++ b/src/components/AppMockup.astro
@@ -1,0 +1,126 @@
+---
+// SVG mockup of the WorkInPrivate desktop app UI
+---
+
+<div class="app-mockup-wrapper relative mx-auto max-w-3xl">
+  <div class="relative rounded-xl shadow-2xl shadow-indigo-200/50 overflow-hidden border border-gray-200/80 bg-white">
+    <!-- Window Chrome -->
+    <div class="flex items-center gap-2 px-4 py-3 bg-gray-100 border-b border-gray-200">
+      <div class="flex gap-1.5">
+        <div class="w-3 h-3 rounded-full bg-red-400"></div>
+        <div class="w-3 h-3 rounded-full bg-yellow-400"></div>
+        <div class="w-3 h-3 rounded-full bg-green-400"></div>
+      </div>
+      <div class="flex-1 flex justify-center">
+        <div class="bg-white rounded-md px-4 py-1 text-xs text-gray-500 border border-gray-200 font-medium">WorkInPrivate</div>
+      </div>
+      <div class="w-[54px]"></div>
+    </div>
+
+    <!-- App Body -->
+    <div class="flex min-h-[280px] sm:min-h-[340px]">
+      <!-- Sidebar -->
+      <div class="hidden sm:flex flex-col w-52 bg-gray-50 border-r border-gray-200 p-4 gap-1">
+        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-2">Modules</div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+          SEO Writer
+        </div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-gray-600 text-sm hover:bg-gray-100">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>
+          Tech Docs
+        </div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-gray-600 text-sm hover:bg-gray-100">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>
+          Academic
+        </div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-gray-600 text-sm hover:bg-gray-100">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
+          Finance
+        </div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-gray-600 text-sm hover:bg-gray-100">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" /></svg>
+          Healthcare
+        </div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-gray-600 text-sm hover:bg-gray-100">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l3 9a5.002 5.002 0 01-6.001 0M18 7l-3 9m-4.529-7.03A3.001 3.001 0 009 10m5.457-3.03A3 3 0 0115 10" /></svg>
+          Legal
+        </div>
+        <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-gray-600 text-sm hover:bg-gray-100">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
+          Small Biz
+        </div>
+      </div>
+
+      <!-- Main Content Area -->
+      <div class="flex-1 p-5 sm:p-6">
+        <!-- Top Bar -->
+        <div class="flex items-center justify-between mb-5">
+          <div>
+            <h3 class="text-sm font-semibold text-gray-900">SEO Writer</h3>
+            <p class="text-xs text-gray-500">Generate SEO-optimized blog articles</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-green-100 text-green-700 text-xs font-medium">
+              <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+              Ollama Connected
+            </span>
+          </div>
+        </div>
+
+        <!-- Input Area -->
+        <div class="space-y-3">
+          <div>
+            <label class="block text-xs font-medium text-gray-500 mb-1">Topic</label>
+            <div class="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-800">Best practices for local SEO in 2026</div>
+          </div>
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <label class="block text-xs font-medium text-gray-500 mb-1">Model</label>
+              <div class="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600 flex items-center justify-between">
+                llama3.1:8b
+                <svg class="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+              </div>
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-500 mb-1">Output Format</label>
+              <div class="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600 flex items-center justify-between">
+                Markdown
+                <svg class="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+              </div>
+            </div>
+          </div>
+          <button class="w-full mt-2 px-4 py-2.5 rounded-lg bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
+            Generate Content
+          </button>
+        </div>
+
+        <!-- Output Preview -->
+        <div class="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-xs font-medium text-gray-500">Output Preview</span>
+            <div class="flex gap-1.5">
+              <div class="w-5 h-5 rounded bg-gray-200 flex items-center justify-center">
+                <svg class="w-3 h-3 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+              </div>
+              <div class="w-5 h-5 rounded bg-gray-200 flex items-center justify-center">
+                <svg class="w-3 h-3 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+              </div>
+            </div>
+          </div>
+          <div class="space-y-1.5 text-xs text-gray-600 leading-relaxed">
+            <div class="h-2.5 bg-gray-300 rounded w-3/4"></div>
+            <div class="h-2 bg-gray-200 rounded w-full"></div>
+            <div class="h-2 bg-gray-200 rounded w-5/6"></div>
+            <div class="h-2 bg-gray-200 rounded w-full"></div>
+            <div class="h-2 bg-gray-200 rounded w-2/3"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Glow effect behind the mockup -->
+  <div class="absolute -inset-4 -z-10 bg-gradient-to-r from-indigo-200 via-indigo-100 to-violet-200 rounded-2xl blur-2xl opacity-40"></div>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import AppMockup from '../components/AppMockup.astro';
 ---
 
 <BaseLayout title="WorkInPrivate - AI Content Generation That Runs on YOUR Machine" description="WorkInPrivate is an AI-powered content generation tool that runs 100% locally using Ollama. No API costs, no cloud, complete privacy. 7 specialized modules for SEO, tech docs, academic, finance, healthcare, legal, and small business content.">
@@ -30,24 +31,52 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   })} />
 
   <!-- Hero Section -->
-  <section class="bg-gradient-to-br from-indigo-50 via-white to-indigo-50 py-20 sm:py-28">
+  <section class="relative overflow-hidden bg-gradient-to-b from-indigo-50 via-white to-gray-50 pt-16 sm:pt-24 pb-20 sm:pb-28">
+    <!-- Decorative background elements -->
+    <div class="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[600px] bg-gradient-to-br from-indigo-100/60 via-violet-100/40 to-transparent rounded-full blur-3xl -z-10"></div>
+    <div class="absolute top-40 -right-20 w-72 h-72 bg-indigo-100/30 rounded-full blur-3xl -z-10"></div>
+    <div class="absolute top-20 -left-20 w-60 h-60 bg-violet-100/30 rounded-full blur-3xl -z-10"></div>
+
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="max-w-4xl mx-auto text-center">
-        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 leading-tight">
-          AI-Powered Content Generation That Runs on <span class="text-indigo-600">YOUR Machine</span>
+      <!-- Text Content -->
+      <div class="max-w-4xl mx-auto text-center mb-12 sm:mb-16">
+        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-indigo-100 text-indigo-700 text-sm font-medium mb-6">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
+          100% Local &amp; Private
+        </div>
+        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 leading-tight tracking-tight">
+          AI Content Generation<br class="hidden sm:block" /> That Runs on <span class="text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 to-violet-600">YOUR Machine</span>
         </h1>
-        <p class="text-xl sm:text-2xl text-gray-600 mb-10 max-w-3xl mx-auto">
-          Generate SEO-optimized articles, technical docs, and specialized content using local LLMs. No API costs. No cloud. Complete privacy.
+        <p class="text-lg sm:text-xl text-gray-600 mb-8 max-w-2xl mx-auto leading-relaxed">
+          Generate SEO articles, technical docs, and specialized content using local LLMs. No API costs. No cloud. Complete privacy.
         </p>
-        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <a href="/pricing" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-200">
-            View Pricing
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 mb-5">
+          <a href="https://buy.stripe.com/test_9B6bJ05et2aW1aD1eeco000" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-xl text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 transition-all shadow-lg shadow-indigo-300/40 hover:shadow-indigo-400/40 hover:-translate-y-0.5 active:translate-y-0 gap-2">
+            Buy Now &mdash; $29
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
           </a>
-          <a href="#how-it-works" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg text-indigo-600 bg-white border-2 border-indigo-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors">
-            How It Works
+          <a href="#how-it-works" class="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-xl text-gray-700 bg-white border border-gray-200 hover:border-gray-300 hover:bg-gray-50 transition-all shadow-sm gap-2">
+            See How It Works
           </a>
         </div>
+        <div class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-gray-500">
+          <span class="inline-flex items-center gap-1.5">
+            <svg class="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+            One-time purchase
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <svg class="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+            30-day money-back guarantee
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <svg class="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+            No subscription
+          </span>
+        </div>
       </div>
+
+      <!-- App Mockup -->
+      <AppMockup />
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Replaced the plain text hero with a visually rich section featuring decorative gradient blobs, a pill badge, gradient text, and stronger visual hierarchy
- Added an interactive-looking **app mockup** (AppMockup component) that shows visitors what WorkInPrivate actually looks like — complete with window chrome, sidebar navigation with all 7 modules, input form, and output preview
- Replaced "View Pricing" button with a direct **"Buy Now — $29"** CTA linking straight to Stripe checkout — purchase in 1 click from the homepage
- Added **trust signals** below the CTA: "One-time purchase", "30-day money-back guarantee", "No subscription"
- Kept "See How It Works" as a secondary CTA

Partially addresses #22 (Section 1: Hero Section Overhaul)

## Test plan
- [ ] Verify hero renders correctly on mobile (< 640px) — sidebar should hide, mockup should stack below text
- [ ] Verify hero renders correctly on tablet (640px–1024px) and desktop (1024px+)
- [ ] Click "Buy Now — $29" button and confirm it opens the Stripe checkout
- [ ] Verify trust signals display and wrap properly on small screens
- [ ] Verify the gradient text ("YOUR Machine") renders in all major browsers
- [ ] Check that decorative gradient blobs don't cause horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)