### PR TITLE
Update favicon to WiP with dark terminal theme

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="20" fill="#4F46E5"/>
-  <text x="50" y="70" font-family="Arial, sans-serif" font-size="45" font-weight="bold" fill="white" text-anchor="middle">WP</text>
+  <!-- Dark terminal background -->
+  <rect width="100" height="100" rx="16" fill="#0a0e17"/>
+
+  <!-- Subtle border with accent colors -->
+  <rect width="100" height="100" rx="16" fill="none" stroke="url(#borderGradient)" stroke-width="2"/>
+
+  <!-- Gradient definition -->
+  <defs>
+    <linearGradient id="borderGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#22c55e;stop-opacity:0.6" />
+      <stop offset="50%" style="stop-color:#22d3ee;stop-opacity:0.6" />
+      <stop offset="100%" style="stop-color:#e879f9;stop-opacity:0.6" />
+    </linearGradient>
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#22c55e" />
+      <stop offset="50%" style="stop-color:#22d3ee" />
+      <stop offset="100%" style="stop-color:#e879f9" />
+    </linearGradient>
+  </defs>
+
+  <!-- Text "WiP" in monospace style with gradient -->
+  <text x="50" y="68" font-family="'Courier New', monospace" font-size="36" font-weight="bold" fill="url(#textGradient)" text-anchor="middle">WiP</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replace "WP" favicon with "WiP" using monospace font
- Update background from purple (#4F46E5) to dark terminal theme (#0a0e17)
- Add green/cyan/fuchsia gradient to text and border for visual consistency with site

## Changes
- `public/favicon.svg` - Complete redesign with dark theme and gradient accents

## Visual Changes
The browser tab icon now displays "WiP" in monospace font with a colorful gradient that matches the site's terminal aesthetic (green → cyan → fuchsia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)