### PR TITLE
feat: add legal pages for Terms of Sale, Privacy Policy, and Refund Policy

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,6 +13,9 @@
         <a href="/privacy" class="text-gray-500 hover:text-green-400 transition-colors">
           Privacy Policy
         </a>
+        <a href="/refund" class="text-gray-500 hover:text-green-400 transition-colors">
+          Refund Policy
+        </a>
         <a href="/license" class="text-gray-500 hover:text-green-400 transition-colors">
           License Agreement
         </a>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -8,9 +8,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-3xl mx-auto prose prose-gray prose-indigo">
         <h1 class="text-4xl font-bold text-gray-900 mb-2">Privacy Policy</h1>
-        <p class="text-sm text-gray-500 mb-10">Last updated: February 15, 2026</p>
+        <p class="text-sm text-gray-500 mb-10">Last updated: February 22, 2026</p>
 
-        <p>WorkInPrivate is built on a simple principle: your data is yours. This Privacy Policy explains what information we collect, how we use it, and your rights regarding your data.</p>
+        <p>This Privacy Policy describes how Wallco Digital Labs LLC ("we," "us," or "our") collects, uses, and shares your personal information when you visit www.workinprivate.com ("Website"), purchase our software, or use our services.</p>
 
         <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">1. The Short Version</h2>
         <div class="bg-indigo-50 rounded-xl p-6 not-prose mb-6">
@@ -25,7 +25,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </li>
             <li class="flex items-start">
               <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
-              <span>We only collect data necessary to process your purchase (via Stripe)</span>
+              <span>We only collect data necessary to process your purchase and deliver your license</span>
             </li>
             <li class="flex items-start">
               <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
@@ -34,33 +34,79 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </ul>
         </div>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. The WorkInPrivate Application</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. Information We Collect</h2>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Information You Provide</h3>
+        <p>When you make a purchase or interact with us, we may collect:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li><strong>Email address</strong> — provided during checkout for license key delivery and account communication</li>
+          <li><strong>Name</strong> — if provided during checkout</li>
+          <li><strong>Purchase details</strong> — which products, modules, and OS version you selected</li>
+        </ul>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Payment Information</h3>
+        <p>Payment is processed by <strong>Stripe, Inc.</strong> We do <strong>not</strong> directly collect, store, or have access to your full credit card number, debit card number, or bank account details. Stripe handles all payment data in accordance with PCI-DSS standards. See <a href="https://stripe.com/privacy" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Stripe's Privacy Policy</a>.</p>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Information Collected Automatically</h3>
+        <p>When you visit the Website, we may automatically collect:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>IP address</li>
+          <li>Browser type and version</li>
+          <li>Operating system</li>
+          <li>Pages visited and time spent on pages</li>
+          <li>Referring website or source</li>
+        </ul>
+        <p>This information is collected through standard server logs by our hosting provider.</p>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Customer Database</h3>
+        <p>We use <strong>Supabase</strong> as our database provider to store your email address, purchase history, license key information, and account creation date. See <a href="https://supabase.com/privacy" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Supabase's Privacy Policy</a>.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. How We Use Your Information</h2>
+        <p>We use the information we collect for:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li><strong>License delivery</strong> — Sending your license key via email after purchase</li>
+          <li><strong>Module ownership tracking</strong> — Recording which modules you have purchased</li>
+          <li><strong>Payment processing</strong> — Processing your purchase through Stripe</li>
+          <li><strong>Customer support</strong> — Responding to your questions and requests</li>
+          <li><strong>Order fulfillment</strong> — Delivering the correct OS version and modules</li>
+          <li><strong>Legal compliance</strong> — Meeting our legal obligations (e.g., tax records)</li>
+          <li><strong>Communication</strong> — Sending transactional emails (order confirmations, license delivery, important product updates)</li>
+        </ul>
+        <p>We do <strong>not</strong> use your information for selling to third parties, targeted advertising, or profiling.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. The WorkInPrivate Application</h2>
         <p>The WorkInPrivate desktop application is designed with privacy as a core feature:</p>
         <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Local processing:</strong> All content generation happens on your device using AI models running through Ollama. Your prompts, inputs, and generated content are processed locally and are never sent to our servers.</li>
+          <li><strong>Local processing:</strong> All content generation happens on your device using AI models running through Ollama. Your prompts, inputs, and generated content are processed locally and never sent to our servers.</li>
           <li><strong>No telemetry:</strong> The application does not collect usage data, crash reports, or analytics of any kind.</li>
           <li><strong>No accounts:</strong> The application does not require you to create an account or sign in.</li>
-          <li><strong>Optional web search:</strong> If you enable the web search feature, search queries are sent to third-party search providers. This feature is optional and can be disabled. We do not log or store your search queries.</li>
+          <li><strong>Optional web search:</strong> If you enable the web search feature, search queries are sent to DuckDuckGo. This feature is optional and can be disabled. We do not log or store your search queries.</li>
         </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. This Website</h2>
-        <p>When you visit www.workinprivate.com, we may collect:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Standard server logs:</strong> Your IP address, browser type, and pages visited may be logged by our hosting provider (GitHub Pages) as part of standard web server operations.</li>
-          <li><strong>No cookies:</strong> This website does not use tracking cookies or third-party analytics scripts.</li>
-        </ul>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. Third-Party Services</h2>
+        <p>We share your information only with the following service providers:</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. Payment Processing</h2>
-        <p>When you purchase WorkInPrivate, your payment is processed by <strong>Stripe</strong>, a third-party payment processor. During this process:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Stripe collects your payment information (credit/debit card details, billing address, email) directly. We do not see or store your full card number.</li>
-          <li>We receive from Stripe: your name, email address, purchase details, and a transaction identifier.</li>
-          <li>We use this information solely to fulfill your order and provide customer support (e.g., processing refunds).</li>
-          <li>Stripe's handling of your payment data is governed by <a href="https://stripe.com/privacy" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Stripe's Privacy Policy</a>.</li>
-        </ul>
+        <div class="bg-indigo-50 rounded-xl p-6 not-prose mb-6">
+          <div class="space-y-4">
+            <div>
+              <p class="font-semibold text-gray-900">Stripe (Payment Processing)</p>
+              <p class="text-gray-700 text-sm">Receives: payment information, email, purchase details</p>
+              <p class="text-gray-700 text-sm">Policy: <a href="https://stripe.com/privacy" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">stripe.com/privacy</a></p>
+            </div>
+            <div>
+              <p class="font-semibold text-gray-900">Supabase (Database Hosting)</p>
+              <p class="text-gray-700 text-sm">Receives: email, purchase history, license information</p>
+              <p class="text-gray-700 text-sm">Policy: <a href="https://supabase.com/privacy" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">supabase.com/privacy</a></p>
+            </div>
+            <div>
+              <p class="font-semibold text-gray-900">GitHub Pages (Website Hosting)</p>
+              <p class="text-gray-700 text-sm">Receives: standard web server logs (IP address, browser info)</p>
+              <p class="text-gray-700 text-sm">Policy: <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">GitHub Privacy Statement</a></p>
+            </div>
+          </div>
+        </div>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. Third-Party AI Models</h2>
-        <p>WorkInPrivate uses Ollama to run AI models locally on your device. These models are downloaded from Ollama's model registry. While the models run locally, the initial download of models is subject to <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Ollama's privacy practices</a>. Once downloaded, models operate entirely offline.</p>
+        <p>We may also disclose your information if required by law or in response to valid legal requests.</p>
 
         <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">6. Data We Do NOT Collect</h2>
         <p>To be explicit, we do <strong>not</strong> collect:</p>
@@ -68,31 +114,60 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <li>Your prompts or inputs to the application</li>
           <li>Content generated by the application</li>
           <li>Usage patterns or application analytics</li>
-          <li>Device information beyond what's in standard server logs</li>
           <li>Location data</li>
         </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. Data Retention</h2>
-        <p>Purchase records (name, email, transaction details) are retained for as long as necessary to provide customer support and comply with legal obligations (e.g., tax records). You may request deletion of your personal data by contacting us.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. Third-Party AI Models</h2>
+        <p>WorkInPrivate uses Ollama to run AI models locally on your device. Models are downloaded from Ollama's model registry. While the models run locally, the initial download is subject to <a href="https://ollama.com" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Ollama's privacy practices</a>. Once downloaded, models operate entirely offline.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Your Rights</h2>
-        <p>Depending on your jurisdiction, you may have the right to:</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Cookies and Tracking</h2>
+        <p>This website uses only essential cookies required for the checkout process. We do not use tracking cookies or third-party analytics scripts. We respect Do Not Track (DNT) browser signals.</p>
+        <p>You can control cookies through your browser settings. Disabling essential cookies may affect checkout functionality.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">9. Data Retention</h2>
         <ul class="list-disc pl-6 space-y-2">
-          <li>Access the personal data we hold about you</li>
-          <li>Request correction of inaccurate data</li>
-          <li>Request deletion of your data</li>
-          <li>Object to or restrict processing of your data</li>
+          <li><strong>Email address:</strong> Retained as long as your license is active, plus 3 years</li>
+          <li><strong>Purchase history:</strong> 7 years (tax and legal compliance)</li>
+          <li><strong>License key records:</strong> As long as your license is active, plus 1 year</li>
+          <li><strong>Website analytics:</strong> 26 months</li>
+          <li><strong>Support correspondence:</strong> 3 years after last communication</li>
         </ul>
-        <p>To exercise these rights, please contact us through our GitHub page.</p>
+        <p>After the retention period expires, we will securely delete or anonymize your data.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">9. Children's Privacy</h2>
-        <p>WorkInPrivate is not intended for use by anyone under 18 years of age. We do not knowingly collect personal information from children under 18.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">10. Data Security</h2>
+        <p>We implement appropriate measures to protect your personal information, including encrypted data transmission (HTTPS/TLS), secure third-party providers (Stripe is PCI-DSS certified; Supabase provides encryption at rest and in transit), and access controls. No method of transmission over the Internet is 100% secure, and we cannot guarantee absolute security.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">10. Changes to This Policy</h2>
-        <p>We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated date. We encourage you to review this policy periodically.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">11. Your Rights</h2>
+        <p>Regardless of your location, you have the right to:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li><strong>Access</strong> — Request a copy of the personal information we hold about you</li>
+          <li><strong>Correction</strong> — Request correction of inaccurate personal information</li>
+          <li><strong>Deletion</strong> — Request deletion of your personal information</li>
+          <li><strong>Portability</strong> — Request a copy of your data in a machine-readable format</li>
+        </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">11. Contact</h2>
-        <p>For privacy-related questions or requests, please visit <a href="https://github.com/wallco26/workinprivate" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">our GitHub page</a>.</p>
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">California Residents (CCPA/CPRA)</h3>
+        <p>If you are a California resident, you have additional rights:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li><strong>Right to Know</strong> — Request details about categories and specific pieces of personal information we have collected, sources, purposes, and third parties we share with.</li>
+          <li><strong>Right to Delete</strong> — Request deletion of your personal information, subject to certain exceptions.</li>
+          <li><strong>Right to Opt-Out of Sale</strong> — We do <strong>not</strong> sell your personal information.</li>
+          <li><strong>Right to Non-Discrimination</strong> — We will not discriminate against you for exercising your privacy rights.</li>
+          <li><strong>Right to Correct</strong> — Request correction of inaccurate personal information.</li>
+        </ul>
+        <p>To exercise any of these rights, contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>. We will respond to verifiable requests within 45 days.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">12. International Users</h2>
+        <p>Our services are operated from the United States. If you access the Website from outside the US, your information may be transferred to, stored, and processed in the United States. By using the Website, you consent to this transfer. If you are in the EEA or UK, we process your data on the legal bases of contract performance and legitimate interests. You may have additional rights under the GDPR.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">13. Children's Privacy</h2>
+        <p>WorkInPrivate is not intended for use by anyone under 18. We do not knowingly collect personal information from children under 18. If we discover we have inadvertently collected information from a child under 18, we will promptly delete it. If you are a parent or guardian and believe your child has provided us with personal information, contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">14. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time. When we make changes, we will update the "Last Updated" date at the top of this page. For material changes, we will make reasonable efforts to notify you via email or by posting a prominent notice on the Website.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">15. Contact</h2>
+        <p>For privacy-related questions or requests, contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>. Please include "Privacy" in the subject line.</p>
       </div>
     </div>
   </section>

--- a/src/pages/refund.astro
+++ b/src/pages/refund.astro
@@ -1,0 +1,90 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Refund Policy - WorkInPrivate" description="Refund Policy for WorkInPrivate — 30-day money-back guarantee on all purchases.">
+
+  <section class="py-16 sm:py-20 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto prose prose-gray prose-indigo">
+        <h1 class="text-4xl font-bold text-gray-900 mb-2">Refund Policy</h1>
+        <p class="text-sm text-gray-500 mb-10">Last updated: February 22, 2026</p>
+
+        <p>We want you to be satisfied with your purchase of WorkInPrivate. This Refund Policy explains the terms under which you may request a refund.</p>
+
+        <div class="bg-indigo-50 rounded-xl p-6 not-prose mb-6">
+          <p class="font-semibold text-gray-900 mb-2">30-Day Money-Back Guarantee</p>
+          <p class="text-gray-700">If WorkInPrivate does not meet your expectations, you may request a full refund within 30 days of your purchase date. No questions asked.</p>
+        </div>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">1. Refund Window</h2>
+        <p>You may request a full refund within <strong>30 days</strong> of your original purchase date. The purchase date is the date the payment was successfully processed, as shown on your email receipt.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. What Can Be Refunded</h2>
+        <ul class="list-disc pl-6 space-y-2">
+          <li><strong>Base application</strong> — Full refund within 30 days</li>
+          <li><strong>Individual modules</strong> — Full refund of the module price within 30 days</li>
+          <li><strong>Bundles</strong> — Full refund of the bundle price within 30 days</li>
+        </ul>
+        <p>Bundles are refunded as a whole. Partial refunds for individual modules within a bundle are not available. Individual module purchases may be refunded separately without affecting your base application license or other module licenses.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. Non-Refundable Scenarios</h2>
+        <p>Refunds will <strong>not</strong> be granted if:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>The request is made after the 30-day window has passed</li>
+          <li>Your license has been terminated due to a violation of the <a href="/terms" class="text-indigo-600 hover:text-indigo-700">Terms of Sale</a> or <a href="/license" class="text-indigo-600 hover:text-indigo-700">License Agreement</a></li>
+          <li>You have shared or redistributed your license key</li>
+        </ul>
+        <p>If you purchased the wrong OS version, see Section 6 (Exchanges) instead of requesting a refund.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. How to Request a Refund</h2>
+        <p>To request a refund, email us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a> with:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>Subject line: "Refund Request"</li>
+          <li>Your email address used for the purchase</li>
+          <li>Order confirmation number or Stripe transaction ID</li>
+          <li>Reason for the refund (optional, but helps us improve)</li>
+        </ul>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Processing Time</h3>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>We will acknowledge your request within <strong>2 business days</strong></li>
+          <li>Approved refunds are processed within <strong>5 business days</strong> of approval</li>
+          <li>The refund will appear on your statement within <strong>5–10 business days</strong> after processing, depending on your financial institution</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. What Happens After a Refund</h2>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Full Refund (Base Application or Bundle)</h3>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>Your license key will be deactivated</li>
+          <li>All associated module licenses will be removed</li>
+          <li>You must uninstall all copies of WorkInPrivate from your devices</li>
+          <li>You will no longer have access to software updates or support</li>
+        </ul>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Module-Only Refund</h3>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>The refunded module will be removed from your account</li>
+          <li>Your base application license and other module licenses remain active</li>
+          <li>You retain access to all non-refunded products</li>
+        </ul>
+
+        <p class="mt-4">All refunds are issued to the original payment method via Stripe. We do not issue refunds by check, cash, or alternative payment methods.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">6. Exchanges</h2>
+        <p>If you purchased the wrong OS version (e.g., Windows instead of macOS), contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a> within 30 days. We will exchange your license for the correct platform at no additional cost.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. Disputes</h2>
+        <p>If your refund request is denied and you believe this is in error, reply to our denial email with additional information. We will review your case within 5 business days and provide a final decision. We encourage resolving disputes directly with us before contacting your payment provider.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Changes to This Policy</h2>
+        <p>We may update this Refund Policy from time to time. Changes will be posted on this page with an updated date. The refund terms in effect at the time of your purchase will apply to that purchase.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">9. Contact</h2>
+        <p>For refund requests or questions about this policy, contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>.</p>
+      </div>
+    </div>
+  </section>
+
+</BaseLayout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -2,37 +2,77 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Terms of Service - WorkInPrivate" description="Terms of Service for WorkInPrivate — AI-powered content generation software.">
+<BaseLayout title="Terms of Sale - WorkInPrivate" description="Terms of Sale for WorkInPrivate — AI-powered content generation software by Wallco Digital Labs LLC.">
 
   <section class="py-16 sm:py-20 bg-white">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-3xl mx-auto prose prose-gray prose-indigo">
-        <h1 class="text-4xl font-bold text-gray-900 mb-2">Terms of Service</h1>
-        <p class="text-sm text-gray-500 mb-10">Last updated: February 15, 2026</p>
+        <h1 class="text-4xl font-bold text-gray-900 mb-2">Terms of Sale</h1>
+        <p class="text-sm text-gray-500 mb-10">Last updated: February 22, 2026</p>
 
-        <p>Welcome to WorkInPrivate. By purchasing, downloading, installing, or using WorkInPrivate software ("the Software"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use the Software.</p>
+        <p>These Terms of Sale ("Terms") govern your purchase and use of WorkInPrivate software and related services through our website at www.workinprivate.com ("Website"). By completing a purchase, you agree to be bound by these Terms.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">1. Overview</h2>
-        <p>WorkInPrivate is an AI-powered content generation tool that runs locally on your computer using Ollama. The Software generates specialized content across multiple modules including SEO, technical documentation, academic, finance, healthcare, legal, and small business content.</p>
+        <p>These Terms are separate from and in addition to the <a href="/license" class="text-indigo-600 hover:text-indigo-700">Proprietary Software License Agreement</a> ("LICENSE") that governs your use of the WorkInPrivate application.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. Eligibility</h2>
-        <p>You must be at least 18 years of age to purchase or use the Software. If you are under 18, you may only use the Software with the involvement and consent of a parent or legal guardian.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">1. Products and Pricing</h2>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. Purchase and Payment</h2>
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Software Products</h3>
+        <p>WorkInPrivate is a desktop application available for Windows, macOS, and Linux. You must select your operating system at the time of purchase. Each OS version is a separate product. If you need the software on a different operating system, a separate purchase is required.</p>
+
+        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Pricing Structure</h3>
+        <p>WorkInPrivate uses a modular pricing structure:</p>
         <ul class="list-disc pl-6 space-y-2">
-          <li>All purchases are processed through Stripe, a third-party payment processor.</li>
-          <li>Prices are listed in US dollars and are subject to change without notice.</li>
-          <li>The Software is licensed on a one-time purchase basis — there are no recurring subscription fees.</li>
-          <li>By completing a purchase, you agree to Stripe's terms of service and privacy policy.</li>
+          <li><strong>Base Application</strong> — The core WorkInPrivate application with the default SEO Writer module.</li>
+          <li><strong>Individual Modules</strong> — Additional content generation modules (e.g., Tech Docs, Academic, Small Business, Legal, Healthcare, Finance) available for individual purchase.</li>
+          <li><strong>Bundles</strong> — Discounted packages combining the base application with multiple modules.</li>
+        </ul>
+        <p>All prices are listed on the Website in United States Dollars (USD) and are subject to change. Price changes do not affect previously completed purchases. You are responsible for any applicable taxes, duties, or fees imposed by your jurisdiction.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. Payment Terms</h2>
+        <p>All payments are processed securely through <strong>Stripe, Inc.</strong> By making a purchase, you also agree to <a href="https://stripe.com/legal" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Stripe's terms and conditions</a>.</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>We accept credit cards, debit cards, and other payment methods supported by Stripe.</li>
+          <li>We do not directly store your full credit card number or bank account information. Payment data is handled entirely by Stripe.</li>
+          <li>Upon successful payment, you will receive an email confirmation at the address you provide during checkout.</li>
+          <li>If a payment fails, no license key will be delivered and you will not be charged.</li>
         </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. Refund Policy</h2>
-        <p>We offer a 30-day money-back guarantee. If WorkInPrivate does not meet your expectations, contact us within 30 days of purchase for a full refund. After 30 days, all sales are final.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. License Delivery</h2>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>After successful payment, a license key will be delivered to the email address you provide during checkout. Delivery is typically immediate but may take up to 24 hours.</li>
+          <li>Your license key activates the WorkInPrivate application and the specific modules you purchased.</li>
+          <li>Each license key may be used on up to <strong>three (3) devices</strong> that you personally own or control, all running the OS version you purchased.</li>
+          <li>License keys are <strong>non-transferable</strong>. You may not sell, give away, share, or otherwise transfer your license key to another person or entity.</li>
+        </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. License</h2>
-        <p>Your use of the Software is governed by the <a href="/license" class="text-indigo-600 hover:text-indigo-700">License Agreement (EULA)</a>. The Software is licensed, not sold. You receive a personal, non-exclusive, non-transferable license to use the Software in accordance with the License Agreement.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. Module Licensing</h2>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>Your purchased modules are tracked in your customer account. You own a license to use the specific modules you purchased for as long as your license remains valid.</li>
+          <li>You may purchase additional modules at any time through the Website. New module licenses are added to your existing account.</li>
+          <li>Bundle pricing is available only at the time of initial purchase. Individual modules purchased separately cannot be retroactively converted to a bundle price.</li>
+        </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">6. Content Disclaimers</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. Updates and Support</h2>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>Your license includes free updates within your purchased major version (e.g., all 1.x updates). Major version upgrades (e.g., 1.x to 2.x) may require a separate purchase or upgrade fee.</li>
+          <li>Support is available via email at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>.</li>
+          <li>Support covers installation, activation, and basic usage. We do not provide support for third-party software (including Ollama or AI models), hardware configuration, or content strategy.</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">6. Eligibility</h2>
+        <p>You must be at least 18 years of age to purchase or use the Software. If you are under 18, you may only use the Software with the involvement and consent of a parent or legal guardian.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. Website Usage</h2>
+        <p>You agree to use the Website only for lawful purposes. You may not:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>Attempt to gain unauthorized access to any part of the Website</li>
+          <li>Interfere with or disrupt the Website or its servers</li>
+          <li>Use automated tools to scrape, crawl, or extract data from the Website</li>
+          <li>Impersonate any person or entity</li>
+        </ul>
+        <p>All content on the Website is the property of Wallco Digital Labs LLC and is protected by copyright and trademark laws.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Content Disclaimers</h2>
         <p>The Software generates content using artificial intelligence. All generated content is subject to the following disclaimers:</p>
 
         <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">AI-Generated Content</h3>
@@ -44,7 +84,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
         <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Finance Module</h3>
         <p class="font-semibold">Content generated by the Finance module is NOT financial, investment, tax, or legal advice.</p>
-        <p>Always consult with a qualified financial advisor, accountant, or other professional before making financial decisions. Past performance does not guarantee future results.</p>
+        <p>Always consult with a qualified financial advisor, accountant, or other professional before making financial decisions.</p>
 
         <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Legal Module</h3>
         <p class="font-semibold">Content generated by the Legal module is NOT legal advice.</p>
@@ -53,15 +93,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Third-Party AI Models</h3>
         <p>The Software uses third-party AI models accessed via Ollama. Wallco Digital Labs LLC does not control, warrant, or assume liability for these third-party models, their training data, outputs, or performance.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. User Responsibilities</h2>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>You are solely responsible for how you use content generated by the Software.</li>
-          <li>You must exercise independent judgment and seek appropriate professional advice before relying on generated content.</li>
-          <li>You must ensure generated content does not infringe third-party intellectual property rights.</li>
-          <li>You agree not to use the Software for any unlawful purpose.</li>
-        </ul>
-
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Acceptable Use</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">9. Acceptable Use</h2>
         <p>You agree NOT to use the Software for:</p>
         <ul class="list-disc pl-6 space-y-2">
           <li>Any illegal activities including fraud, harassment, or discrimination</li>
@@ -72,20 +104,42 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <li>Violating healthcare regulations (HIPAA), financial regulations (SEC, FINRA), or other applicable industry regulations</li>
         </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">9. Limitation of Liability</h2>
-        <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, WALLCO DIGITAL LABS LLC SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR USE OF THE SOFTWARE, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, OR BUSINESS OPPORTUNITIES.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">10. Refunds</h2>
+        <p>Refunds are governed by our separate <a href="/refund" class="text-indigo-600 hover:text-indigo-700">Refund Policy</a>. Please review the Refund Policy before making a purchase.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">10. Indemnification</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">11. Termination</h2>
+        <p>We may terminate or suspend your license if you violate these Terms, the software <a href="/license" class="text-indigo-600 hover:text-indigo-700">License Agreement</a>, engage in fraudulent activity, or share/redistribute your license key. Upon termination:</p>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>Your license key will be deactivated</li>
+          <li>All associated module licenses will be removed</li>
+          <li>You must uninstall all copies of the software from your devices</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">12. Limitation of Liability</h2>
+        <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, WALLCO DIGITAL LABS LLC SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR PURCHASE OR USE OF THE SOFTWARE, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, OR BUSINESS OPPORTUNITIES. OUR TOTAL LIABILITY SHALL NOT EXCEED THE AMOUNT YOU PAID FOR THE SOFTWARE.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">13. Indemnification</h2>
         <p>You agree to indemnify and hold harmless Wallco Digital Labs LLC, its affiliates, officers, directors, employees, and agents from any claims, liabilities, damages, losses, or expenses arising from your use of the Software, violation of these Terms, or infringement of any third-party rights.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">11. Changes to Terms</h2>
-        <p>Wallco Digital Labs LLC reserves the right to modify these Terms at any time. Changes will be posted on this page with an updated date. Continued use of the Software after modifications constitutes acceptance of the updated Terms.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">14. Governing Law</h2>
+        <p>These Terms are governed by the laws of the State of California, United States, without regard to conflicts of law principles. Any disputes shall be resolved exclusively in the state or federal courts located in the State of California. Before filing any legal claim, you agree to attempt to resolve the dispute informally by contacting us.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">12. Governing Law</h2>
-        <p>These Terms are governed by the laws of the State of California, United States, without regard to conflicts of law principles. Any disputes shall be resolved exclusively in the courts of California.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">15. Relationship to Software License</h2>
+        <p>These Terms govern the purchase transaction and website usage. The WorkInPrivate software itself is governed by the <a href="/license" class="text-indigo-600 hover:text-indigo-700">Proprietary Software License Agreement</a> included with the application. In the event of a conflict, the License Agreement governs software usage, and these Terms govern the purchase transaction and website.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">13. Contact</h2>
-        <p>For questions about these Terms, please visit <a href="https://github.com/wallco26/workinprivate" class="text-indigo-600 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">our GitHub page</a>.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">16. General Provisions</h2>
+        <ul class="list-disc pl-6 space-y-2">
+          <li>These Terms, together with the <a href="/privacy" class="text-indigo-600 hover:text-indigo-700">Privacy Policy</a>, <a href="/refund" class="text-indigo-600 hover:text-indigo-700">Refund Policy</a>, and software <a href="/license" class="text-indigo-600 hover:text-indigo-700">License Agreement</a>, constitute the entire agreement regarding the purchase of WorkInPrivate.</li>
+          <li>If any provision of these Terms is found to be invalid or unenforceable, the remaining provisions shall remain in full force and effect.</li>
+          <li>Our failure to enforce any provision does not constitute a waiver of that or any other provision.</li>
+          <li>You may not assign or transfer your rights under these Terms without our written consent.</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">17. Changes to Terms</h2>
+        <p>We reserve the right to modify these Terms at any time. Changes will be posted on this page with an updated date. Continued use of the Website or software after modifications constitutes acceptance. We will make reasonable efforts to notify existing customers of material changes via email.</p>
+
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">18. Contact</h2>
+        <p>For questions about these Terms, contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Updates `terms.astro` with comprehensive Terms of Sale content (pricing, payment, license delivery, modules, support, acceptable use, termination, governing law)
- Updates `privacy.astro` with full CCPA/CPRA-compliant Privacy Policy (data collected, third-party services with disclosure boxes, cookies, retention schedules, California resident rights, international users)
- Creates new `refund.astro` page with 30-day refund policy (eligibility, process, license deactivation, exchanges)
- Adds "Refund Policy" link to `Footer.astro` alongside existing legal links
- All contact references use support@workinprivate.com (no GitHub repo links)

Related to workinprivate repo issue #29 and PR #81.

## Test plan

- [ ] Verify `/terms` page renders correctly with all sections
- [ ] Verify `/privacy` page renders correctly with third-party service disclosure boxes
- [ ] Verify `/refund` page renders correctly with 30-day guarantee callout box
- [ ] Verify footer shows all four legal links (Terms, Privacy, Refund, License)
- [ ] Cross-check content consistency between site pages and `legal/` markdown docs in workinprivate repo
- [ ] Test on mobile viewports for readability
- [ ] Playwright tests pass on desktop browsers (288/300 pass; 12 pre-existing mobile nav failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)