### PR TITLE
Activate all download links and show dynamic version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  repository_dispatch:
+    types: [ cli-release ]
 
 permissions:
   contents: read

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -1,5 +1,17 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+
+let version = 'latest';
+try {
+  const res = await fetch('https://api.github.com/repos/wallco26/workinprivate/releases/tags/latest');
+  if (res.ok) {
+    const data = await res.json();
+    const match = data.name?.match(/v?([\d.]+)/);
+    if (match) version = match[1];
+  }
+} catch {}
+
+const baseUrl = 'https://github.com/wallco26/workinprivate/releases/latest/download';
 ---
 
 <BaseLayout title="Download WorkInPrivate" description="Thank you for your purchase! Download WorkInPrivate for Windows, macOS, or Linux.">
@@ -14,6 +26,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </div>
       <h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Thank You for Your Purchase!</h1>
       <p class="text-xl text-gray-600 max-w-2xl mx-auto">Your download is ready. Choose your platform below to get started.</p>
+      <span class="inline-block mt-4 px-3 py-1 text-sm font-medium text-indigo-700 bg-indigo-100 rounded-full">Version {version}</span>
     </div>
   </section>
 
@@ -32,12 +45,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-2">Windows</h3>
             <p class="text-sm text-gray-500 mb-5">.exe (portable zip)</p>
-            <!-- TODO: Replace with actual download URL when Windows build is available -->
-            <a href="#" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-gray-400 cursor-not-allowed">
+            <a href={`${baseUrl}/WorkInPrivate-Win64.zip`} class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
-              Coming Soon
+              Download for Windows
             </a>
           </div>
 
@@ -49,13 +61,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </svg>
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-2">macOS</h3>
-            <p class="text-sm text-gray-500 mb-5">.app (universal binary)</p>
-            <!-- TODO: Replace with actual download URL when macOS build is available -->
-            <a href="#" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-gray-400 cursor-not-allowed">
+            <p class="text-sm text-gray-500 mb-5">.zip (Apple Silicon)</p>
+            <a href={`${baseUrl}/WorkInPrivate-macOS-ARM.zip`} class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
-              Coming Soon
+              Download for macOS
             </a>
           </div>
 
@@ -68,7 +79,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-2">Linux</h3>
             <p class="text-sm text-gray-500 mb-5">.tar.gz</p>
-            <a href="https://github.com/wallco26/workinprivate/releases/download/v1.0.0/WorkInPrivate-Linux.tar.gz" class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
+            <a href={`${baseUrl}/WorkInPrivate-Linux.tar.gz`} class="inline-flex items-center justify-center w-full px-6 py-3 text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 transition-colors">
               <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch` trigger (`cli-release`) to `deploy.yml` so the site rebuilds when the CLI publishes a new release
- Fetches latest version from GitHub API at build time and displays a version badge
- Activates Windows and macOS download buttons (previously "Coming Soon")
- All download URLs use `/releases/latest/download/` pattern (version-independent)

## Test plan
- [ ] Run `npm run build` — verify no build errors
- [ ] Run `npx playwright test` — verify no new test failures
- [ ] Check all 3 download links resolve correctly once a `latest` release exists
- [ ] Test cross-repo dispatch: `gh api repos/wallco26/workinprivate-site/dispatches -f event_type=cli-release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)