### PR TITLE
Fix version env var access in download page

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 
-const version = import.meta.env.CLI_VERSION || 'latest';
+const version = process.env.CLI_VERSION || 'latest';
 
 const baseUrl = 'https://github.com/wallco26/workinprivate/releases/latest/download';
 ---


### PR DESCRIPTION
## Summary
Use `process.env.CLI_VERSION` instead of `import.meta.env.CLI_VERSION`. Vite only exposes `PUBLIC_`-prefixed env vars via `import.meta.env`, but `process.env` works in Astro frontmatter at build time.

## Test plan
- [x] `CLI_VERSION=1.0.0 npm run build` → renders "Version 1.0.0"
- [x] `npm run build` (no env var) → renders "Version latest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)