### PR TITLE
Add changelog page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,8 +5,10 @@
 <footer class="bg-[#0a0e17] border-t border-gray-800 mt-auto">
   <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
     <div class="flex flex-col items-center space-y-4">
-      <!-- Legal Links -->
-      <nav aria-label="Legal" class="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm">
+      <nav aria-label="Footer" class="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm">
+        <a href="/changelog" class="text-gray-500 hover:text-green-400 transition-colors">
+          Changelog
+        </a>
         <a href="/terms" class="text-gray-500 hover:text-green-400 transition-colors">
           Terms of Service
         </a>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,0 +1,194 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Changelog - WorkInPrivate" description="Release notes and version history for WorkInPrivate.">
+
+  <!-- Hero -->
+  <section class="bg-gradient-to-br from-indigo-50 via-white to-indigo-50 py-16 sm:py-20">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Changelog</h1>
+      <p class="text-xl text-gray-600 max-w-2xl mx-auto">Release notes and version history for WorkInPrivate.</p>
+    </div>
+  </section>
+
+  <!-- Changelog Content -->
+  <section class="py-16 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto">
+
+        <!-- Loading state -->
+        <div id="changelog-loading" class="text-center py-12">
+          <div class="inline-block w-8 h-8 border-4 border-indigo-200 border-t-indigo-600 rounded-full animate-spin"></div>
+          <p class="mt-4 text-gray-500">Loading release notes...</p>
+        </div>
+
+        <!-- Error state -->
+        <div id="changelog-error" class="hidden text-center py-12">
+          <p class="text-gray-500">Unable to load release notes. Please try again later.</p>
+        </div>
+
+        <!-- Changelog entries rendered here -->
+        <div id="changelog-entries" class="hidden space-y-12"></div>
+
+      </div>
+    </div>
+  </section>
+
+</BaseLayout>
+
+<script is:inline>
+  (function() {
+    var CHANGELOG_URL = 'https://peungwkkkqorgzxfhyaa.supabase.co/functions/v1/get-changelog';
+
+    var CATEGORY_META = {
+      'Features':  { icon: '&#x2728;', color: 'green' },
+      'Fixes':     { icon: '&#x1F41B;', color: 'red' },
+      'UX/UI':     { icon: '&#x1F3A8;', color: 'purple' },
+      'Docs':      { icon: '&#x1F4D6;', color: 'blue' },
+      'Internal':  { icon: '&#x2699;&#xFE0F;', color: 'gray' }
+    };
+
+    var COLOR_CLASSES = {
+      green:  { bg: 'bg-green-50',  border: 'border-green-200', text: 'text-green-700',  badge: 'bg-green-100 text-green-800', dot: 'bg-green-400' },
+      red:    { bg: 'bg-red-50',    border: 'border-red-200',   text: 'text-red-700',    badge: 'bg-red-100 text-red-800',     dot: 'bg-red-400' },
+      purple: { bg: 'bg-purple-50', border: 'border-purple-200',text: 'text-purple-700', badge: 'bg-purple-100 text-purple-800',dot: 'bg-purple-400' },
+      blue:   { bg: 'bg-blue-50',   border: 'border-blue-200',  text: 'text-blue-700',   badge: 'bg-blue-100 text-blue-800',   dot: 'bg-blue-400' },
+      gray:   { bg: 'bg-gray-50',   border: 'border-gray-200',  text: 'text-gray-600',   badge: 'bg-gray-100 text-gray-700',   dot: 'bg-gray-400' }
+    };
+
+    function escapeHtml(str) {
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode(str));
+      return div.innerHTML;
+    }
+
+    function parseReleaseNotes(notes) {
+      var sections = [];
+      var currentSection = null;
+      var lines = notes.split('\n');
+
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        var headerMatch = line.match(/^## (.+)/);
+        if (headerMatch) {
+          var title = headerMatch[1].trim();
+          // Skip the version header (e.g. "v1.0.1 (2026-02-28)")
+          if (title.match(/^v\d/)) continue;
+          currentSection = { title: title, items: [] };
+          sections.push(currentSection);
+          continue;
+        }
+        var itemMatch = line.match(/^- (.+)/);
+        if (itemMatch && currentSection) {
+          currentSection.items.push(itemMatch[1].trim());
+        }
+      }
+      return sections;
+    }
+
+    function formatDate(dateStr) {
+      if (!dateStr) return 'Unknown date';
+      var d = new Date(dateStr);
+      return isNaN(d.getTime()) ? 'Unknown date' : d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+    }
+
+    function severityBadge(severity) {
+      var map = {
+        critical:    '<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800">Critical</span>',
+        recommended: '<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800">Recommended</span>',
+        info:        ''
+      };
+      return map[severity] || '';
+    }
+
+    function renderVersion(version) {
+      var sections = parseReleaseNotes(version.release_notes || '');
+      var date = formatDate(version.created_at);
+      var badge = severityBadge(version.severity);
+
+      var html = '<article class="border border-gray-200 rounded-2xl overflow-hidden">';
+
+      // Version header
+      html += '<div class="px-6 py-5 bg-gray-50 border-b border-gray-200">';
+      html += '<div class="flex flex-wrap items-center gap-3">';
+      html += '<h2 class="text-2xl font-bold text-gray-900 font-mono">v' + escapeHtml(version.version) + '</h2>';
+      html += badge;
+      html += '</div>';
+      html += '<p class="mt-1 text-sm text-gray-500">' + escapeHtml(date) + '</p>';
+      html += '</div>';
+
+      // Sections
+      html += '<div class="px-6 py-5 space-y-6">';
+
+      if (sections.length === 0) {
+        html += '<p class="text-gray-600">' + escapeHtml(version.release_notes || 'Initial release.') + '</p>';
+      }
+
+      for (var i = 0; i < sections.length; i++) {
+        var section = sections[i];
+        // Skip internal/maintenance entries — not useful for end users
+        if (section.title === 'Internal' || section.title === 'Docs') continue;
+        var meta = CATEGORY_META[section.title] || { icon: '&#x1F4CB;', color: 'gray' };
+        var colors = COLOR_CLASSES[meta.color];
+
+        html += '<div>';
+        html += '<h3 class="flex items-center gap-2 text-lg font-semibold ' + colors.text + ' mb-3">';
+        html += '<span class="inline-flex items-center justify-center w-6 h-6 rounded-md ' + colors.badge + ' text-sm">' + meta.icon + '</span>';
+        html += escapeHtml(section.title);
+        html += '</h3>';
+        html += '<ul class="space-y-1.5">';
+
+        for (var j = 0; j < section.items.length; j++) {
+          html += '<li class="flex items-start gap-2 text-sm text-gray-700">';
+          html += '<span class="mt-1.5 w-1.5 h-1.5 rounded-full ' + colors.dot + ' flex-shrink-0"></span>';
+          html += '<span>' + escapeHtml(section.items[j]) + '</span>';
+          html += '</li>';
+        }
+
+        html += '</ul>';
+        html += '</div>';
+      }
+
+      html += '</div>';
+      html += '</article>';
+
+      return html;
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+      var loadingEl = document.getElementById('changelog-loading');
+      var errorEl = document.getElementById('changelog-error');
+      var entriesEl = document.getElementById('changelog-entries');
+
+      fetch(CHANGELOG_URL)
+        .then(function(res) {
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          return res.json();
+        })
+        .then(function(data) {
+          var versions = data.versions || [];
+          if (versions.length === 0) {
+            loadingEl.classList.add('hidden');
+            var p = errorEl.querySelector('p');
+            if (p) p.textContent = 'No release notes available yet.';
+            errorEl.classList.remove('hidden');
+            return;
+          }
+
+          var html = '';
+          for (var i = 0; i < versions.length; i++) {
+            html += renderVersion(versions[i]);
+          }
+
+          entriesEl.innerHTML = html;
+          loadingEl.classList.add('hidden');
+          entriesEl.classList.remove('hidden');
+        })
+        .catch(function() {
+          loadingEl.classList.add('hidden');
+          errorEl.classList.remove('hidden');
+        });
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary
- Added `/changelog` page that fetches release notes from the Supabase `get-changelog` edge function and displays them in a categorized format
- Added "Changelog" link to the footer navigation
- Fixed footer `aria-label` from "Legal" to "Footer" for better semantics

Supports workinprivate#279 — the CLI update notification now points users to this page instead of displaying inline release notes.

## Details

The changelog page:
- Fetches from `get-changelog` edge function (deployed as part of this work)
- Parses markdown release notes into categorized sections (Features, Fixes, UX/UI)
- Filters out Internal and Docs sections that aren't useful to end users
- Handles loading, error, and empty states gracefully
- Matches existing site design patterns (hero + white content area)
- Uses `escapeHtml()` for all API-sourced content to prevent XSS

## Test plan
- [x] Site builds successfully (12 pages)
- [x] All 60 Chromium Playwright tests pass
- [x] Pre-existing mobile test failures unchanged (not related to this change)
- [ ] Manual: visit `/changelog` and verify release notes load and display correctly
- [ ] Manual: verify "Changelog" link appears in footer on all pages
- [ ] Manual: verify loading spinner appears briefly before content loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)