### PR TITLE
Add promo code framework to pricing page

### DIFF
--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,19 +1,19 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 
-// Base package Stripe Payment Links — one per module (Base + Module at $29 each)
-const BASE_LINKS: Record<string, string> = {
-  seo_writer:     'https://buy.stripe.com/28EdR90t7ddKan59PDaR202',
-  tech_docs:      'https://buy.stripe.com/cNifZh6Rv2z6cvd1j7aR204',
-  academic:       'https://buy.stripe.com/8x23cv0t7c9G1Qz1j7aR200',
-  finance:        'https://buy.stripe.com/8x200j3Fj8Xu3YH0f3aR207',
-  healthcare:     'https://buy.stripe.com/dRmeVddfTb5C7aTge1aR209',
-  legal:          'https://buy.stripe.com/9B67sLfo10qY7aTge1aR208',
-  small_business: 'https://buy.stripe.com/fZueVdcbP6Pm0Mv5znaR203',
-};
+// Module display names for add-on cards
+const MODULES = [
+  { id: 'seo_writer', name: 'SEO Writer', desc: 'Generate SEO-optimized blog articles with keyword research, meta descriptions, and proper heading structure.', iconBg: 'bg-green-900/40', iconColor: 'text-green-400', iconPath: 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z' },
+  { id: 'tech_docs', name: 'Tech Docs', desc: 'Create technical documentation from code repositories with clear explanations and API references.', iconBg: 'bg-cyan-900/40', iconColor: 'text-cyan-400', iconPath: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4' },
+  { id: 'academic', name: 'Academic', desc: 'Generate academic papers and research articles with proper citations, abstracts, and scholarly formatting.', iconBg: 'bg-fuchsia-900/40', iconColor: 'text-fuchsia-400', iconPath: 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253' },
+  { id: 'finance', name: 'Finance', desc: 'Financial reports, market analysis, and investment content with appropriate disclaimers and data presentation.', iconBg: 'bg-green-900/40', iconColor: 'text-green-400', iconPath: 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6' },
+  { id: 'healthcare', name: 'Healthcare', desc: 'Healthcare content generation with medical terminology, patient education materials, and compliance-aware formatting.', iconBg: 'bg-cyan-900/40', iconColor: 'text-cyan-400', iconPath: 'M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z' },
+  { id: 'legal', name: 'Legal', desc: 'Legal documents, contracts, and compliance content with proper legal terminology and structure.', iconBg: 'bg-fuchsia-900/40', iconColor: 'text-fuchsia-400', iconPath: 'M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3' },
+  { id: 'small_business', name: 'Small Business', desc: 'Marketing copy, business plans, social media content, and operational documents tailored for small businesses.', iconBg: 'bg-green-900/40', iconColor: 'text-green-400', iconPath: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4' },
+];
 
-// Bundle Stripe Payment Link ($99, all 7 modules)
-const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
+const SUPABASE_URL = 'https://peungwkkkqorgzxfhyaa.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBldW5nd2tra3Fvcmd6eGZoeWFhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE1NTI3MzgsImV4cCI6MjA4NzEyODczOH0.9fjWeAXZbOefOXn3tJFC5Qj9VtEdBY50EOPwQbxfSbs';
 ---
 
 <BaseLayout title="Pricing - WorkInPrivate" description="Get WorkInPrivate starting at $29 for the base package with one module. Add specialized modules for $19 each. No subscriptions, no API costs — pay once, own it forever.">
@@ -23,6 +23,60 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h1 class="text-4xl sm:text-5xl font-bold text-white mb-4">Simple, One-Time Pricing</h1>
       <p class="text-xl text-gray-400 max-w-2xl mx-auto">Pay once, own it forever. No subscriptions, no API fees, no hidden costs.</p>
+    </div>
+  </section>
+
+  <!-- Promo Code Bar -->
+  <section class="bg-gray-950 pt-10 pb-0">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-md mx-auto">
+        <label for="promo-input" class="block text-sm font-semibold text-gray-400 mb-2 text-center">Have a promo code?</label>
+        <div class="flex gap-2">
+          <input
+            id="promo-input"
+            type="text"
+            placeholder="Enter code"
+            class="flex-1 px-4 py-3 rounded-lg bg-gray-800 border border-gray-700 text-white font-mono text-sm focus:outline-none focus:border-green-500 placeholder-gray-500 uppercase"
+          />
+          <button
+            id="promo-apply-btn"
+            type="button"
+            class="px-6 py-3 rounded-lg text-sm font-bold bg-gray-700 text-gray-300 hover:bg-gray-600 transition-colors font-mono"
+          >
+            Apply
+          </button>
+        </div>
+        <div id="promo-result" class="mt-3 text-sm text-center hidden"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Package Deal Card (shown when package promo applied) -->
+  <section id="package-deal-section" class="bg-gray-950 pt-8 pb-0 hidden">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto rounded-2xl border-2 border-cyan-500 shadow-xl overflow-hidden bg-gray-900/70 relative">
+        <div class="absolute -top-0 right-4">
+          <span class="inline-block bg-gradient-to-r from-cyan-400 to-green-400 text-black text-xs font-bold px-3 py-1 rounded-b-lg uppercase tracking-wide shadow-md">Promo Deal</span>
+        </div>
+        <div class="bg-cyan-900/20 px-8 py-4 text-center border-b border-cyan-800">
+          <span id="package-deal-title" class="text-sm font-semibold text-cyan-400 uppercase tracking-wide font-mono">Special Package</span>
+        </div>
+        <div class="px-8 py-10 text-center">
+          <p id="package-deal-desc" class="text-gray-400 mb-4"></p>
+          <div class="mb-4">
+            <span id="package-deal-price" class="text-5xl font-bold text-cyan-400 font-mono"></span>
+            <span class="text-gray-500 ml-2">one-time</span>
+          </div>
+          <p id="package-deal-modules" class="text-sm text-gray-400 mb-6"></p>
+          <button
+            id="package-deal-btn"
+            type="button"
+            class="inline-block w-full max-w-sm px-8 py-4 text-lg font-bold rounded-lg text-black bg-cyan-400 hover:bg-cyan-300 transition-colors shadow-lg font-mono"
+          >
+            Get This Deal
+          </button>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -38,8 +92,8 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
           <div class="px-8 py-10 text-center">
             <h2 class="text-2xl font-bold text-white mb-2">Base Package</h2>
             <p class="text-gray-400 mb-6">The app + 1 module of your choice</p>
-            <div class="mb-6">
-              <span class="text-5xl font-bold text-green-400 font-mono">$29</span>
+            <div class="mb-6" id="base-price-display">
+              <span class="text-5xl font-bold text-green-400 font-mono" id="base-price">$29</span>
               <span class="text-gray-500 ml-2">one-time</span>
             </div>
             <ul class="text-left space-y-3 mb-6">
@@ -84,26 +138,15 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
               </select>
             </div>
 
-            <a
+            <button
               id="base-buy-btn"
-              href={BASE_LINKS.seo_writer}
+              type="button"
               class="block w-full text-center px-8 py-4 text-lg font-bold rounded-lg text-black bg-green-500 hover:bg-green-400 transition-colors shadow-lg font-mono"
             >
               Get Started &mdash; $29
-            </a>
+            </button>
           </div>
         </div>
-
-        <script define:vars={{ BASE_LINKS }}>
-          const select = document.getElementById('base-module-select');
-          const btn = document.getElementById('base-buy-btn');
-          if (select && btn) {
-            select.addEventListener('change', () => {
-              const url = BASE_LINKS[select.value];
-              if (url) btn.href = url;
-            });
-          }
-        </script>
 
         <!-- Complete Bundle -->
         <div class="rounded-2xl border-2 border-green-500 shadow-xl overflow-hidden relative bg-gray-900/70">
@@ -116,11 +159,11 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
           <div class="px-8 py-10 text-center">
             <h2 class="text-2xl font-bold text-white mb-2">All 7 Modules</h2>
             <p class="text-gray-400 mb-6">The app + every module included</p>
-            <div class="mb-2">
-              <span class="text-5xl font-bold text-green-400 font-mono">$99</span>
+            <div class="mb-2" id="bundle-price-display">
+              <span class="text-5xl font-bold text-green-400 font-mono" id="bundle-price">$99</span>
               <span class="text-gray-500 ml-2">one-time</span>
             </div>
-            <p class="text-sm text-green-400 font-medium mb-6">Save $63 vs. buying separately ($162)</p>
+            <p class="text-sm text-green-400 font-medium mb-6" id="bundle-savings">Save $63 vs. buying separately ($162)</p>
             <ul class="text-left space-y-3 mb-8">
               <li class="flex items-start">
                 <svg class="w-5 h-5 text-green-400 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
@@ -147,9 +190,13 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
                 <span class="text-gray-300">Future module updates included</span>
               </li>
             </ul>
-            <a href={BUNDLE_LINK} class="block w-full text-center px-8 py-4 text-lg font-bold rounded-lg text-black bg-green-500 hover:bg-green-400 transition-all shadow-lg shadow-green-500/40 font-mono">
+            <button
+              id="bundle-buy-btn"
+              type="button"
+              class="block w-full text-center px-8 py-4 text-lg font-bold rounded-lg text-black bg-green-500 hover:bg-green-400 transition-all shadow-lg shadow-green-500/40 font-mono"
+            >
               Get Complete Bundle &mdash; $99
-            </a>
+            </button>
           </div>
         </div>
       </div>
@@ -173,110 +220,26 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
       </div>
       <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
 
-        <!-- SEO Writer -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all">
-          <div class="w-10 h-10 bg-green-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+        {MODULES.map((mod, i) => (
+          <div class={`bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all${i === MODULES.length - 1 ? ' sm:col-span-2 lg:col-span-1' : ''}`}>
+            <div class={`w-10 h-10 ${mod.iconBg} rounded-lg flex items-center justify-center mb-3`}>
+              <svg class={`w-5 h-5 ${mod.iconColor}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d={mod.iconPath} /></svg>
+            </div>
+            <h3 class="text-lg font-semibold text-white mb-2">{mod.name}</h3>
+            <p class="text-gray-400 text-sm flex-grow mb-5">{mod.desc}</p>
+            <div class="flex items-center justify-between">
+              <span class="text-2xl font-bold text-white font-mono addon-price" data-module={mod.id}>$19</span>
+              <button
+                type="button"
+                data-product-type="addon"
+                data-module={mod.id}
+                class="addon-buy-btn inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors"
+              >
+                Add Module
+              </button>
+            </div>
           </div>
-          <h3 class="text-lg font-semibold text-white mb-2">SEO Writer</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Generate SEO-optimized blog articles with keyword research, meta descriptions, and proper heading structure.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/14AbJ1cbPa1yeDle5TaR20f" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
-
-        <!-- Tech Docs -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all">
-          <div class="w-10 h-10 bg-cyan-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-cyan-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>
-          </div>
-          <h3 class="text-lg font-semibold text-white mb-2">Tech Docs</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Create technical documentation from code repositories with clear explanations and API references.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/6oUdR94Jn7Tq7aT3rfaR205" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
-
-        <!-- Academic -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all">
-          <div class="w-10 h-10 bg-fuchsia-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-fuchsia-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>
-          </div>
-          <h3 class="text-lg font-semibold text-white mb-2">Academic</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Generate academic papers and research articles with proper citations, abstracts, and scholarly formatting.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/00weVdb7L6Pm1Qz7HvaR20c" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
-
-        <!-- Finance -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all">
-          <div class="w-10 h-10 bg-green-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
-          </div>
-          <h3 class="text-lg font-semibold text-white mb-2">Finance</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Financial reports, market analysis, and investment content with appropriate disclaimers and data presentation.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/eVq8wPa3Hc9G9j16DraR206" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
-
-        <!-- Healthcare -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all">
-          <div class="w-10 h-10 bg-cyan-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-cyan-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" /></svg>
-          </div>
-          <h3 class="text-lg font-semibold text-white mb-2">Healthcare</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Healthcare content generation with medical terminology, patient education materials, and compliance-aware formatting.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/9B6aEXa3HflScvde5TaR20b" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
-
-        <!-- Legal -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all">
-          <div class="w-10 h-10 bg-fuchsia-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-fuchsia-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" /></svg>
-          </div>
-          <h3 class="text-lg font-semibold text-white mb-2">Legal</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Legal documents, contracts, and compliance content with proper legal terminology and structure.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/bJe8wPgs5a1y7aT1j7aR20a" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
-
-        <!-- Small Business -->
-        <div class="bg-gray-900/50 rounded-xl border border-gray-800 p-6 flex flex-col hover:border-green-700 transition-all sm:col-span-2 lg:col-span-1">
-          <div class="w-10 h-10 bg-green-900/40 rounded-lg flex items-center justify-center mb-3">
-            <svg class="w-5 h-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
-          </div>
-          <h3 class="text-lg font-semibold text-white mb-2">Small Business</h3>
-          <p class="text-gray-400 text-sm flex-grow mb-5">Marketing copy, business plans, social media content, and operational documents tailored for small businesses.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-2xl font-bold text-white font-mono">$19</span>
-            <a href="https://buy.stripe.com/aFa28r6RvflS52Le5TaR20d" class="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg text-gray-300 border-2 border-gray-700 hover:bg-green-900/20 hover:border-green-600 hover:text-green-400 transition-colors">
-              Add Module
-            </a>
-          </div>
-        </div>
+        ))}
 
       </div>
     </div>
@@ -375,5 +338,255 @@ const BUNDLE_LINK = 'https://buy.stripe.com/4gMdR92Bf7Tq2UD7HvaR201';
       </div>
     </div>
   </section>
+
+  <script define:vars={{ SUPABASE_URL, SUPABASE_ANON_KEY }}>
+    // ── State ──
+    let activePromo = null; // null or { promo_type, code, discount_percent, ... }
+
+    // ── API helpers ──
+    async function callEdgeFunction(name, body) {
+      const res = await fetch(`${SUPABASE_URL}/functions/v1/${name}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+          'apikey': SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify(body),
+      });
+      return res.json();
+    }
+
+    // ── Promo validation ──
+    async function validatePromo() {
+      const input = document.getElementById('promo-input');
+      const result = document.getElementById('promo-result');
+      const btn = document.getElementById('promo-apply-btn');
+      const code = input.value.trim();
+
+      if (!code) return;
+
+      btn.textContent = 'Checking...';
+      btn.disabled = true;
+
+      try {
+        const data = await callEdgeFunction('validate-promo', { code });
+        result.classList.remove('hidden');
+
+        if (data.valid) {
+          activePromo = data;
+          result.className = 'mt-3 text-sm text-center text-green-400';
+
+          if (data.promo_type === 'discount') {
+            const desc = data.discount_percent
+              ? `${data.discount_percent}% off`
+              : `$${(data.discount_amount_cents / 100).toFixed(0)} off`;
+            result.textContent = `${data.code} applied — ${desc}!`;
+            applyDiscountUI(data);
+          } else if (data.promo_type === 'package') {
+            result.textContent = `${data.code} applied — special package deal!`;
+            applyPackageUI(data);
+          }
+
+          btn.textContent = 'Clear';
+          btn.disabled = false;
+          btn.onclick = clearPromo;
+        } else {
+          activePromo = null;
+          result.className = 'mt-3 text-sm text-center text-red-400';
+          result.textContent = data.error || 'Invalid promo code.';
+          btn.textContent = 'Apply';
+          btn.disabled = false;
+        }
+      } catch {
+        result.classList.remove('hidden');
+        result.className = 'mt-3 text-sm text-center text-red-400';
+        result.textContent = 'Unable to validate code. Try again.';
+        btn.textContent = 'Apply';
+        btn.disabled = false;
+      }
+    }
+
+    function clearPromo() {
+      activePromo = null;
+      document.getElementById('promo-input').value = '';
+      document.getElementById('promo-result').classList.add('hidden');
+
+      const btn = document.getElementById('promo-apply-btn');
+      btn.textContent = 'Apply';
+      btn.onclick = validatePromo;
+
+      // Reset prices
+      document.getElementById('base-price').textContent = '$29';
+      document.getElementById('base-buy-btn').textContent = 'Get Started \u2014 $29';
+      document.getElementById('bundle-price').textContent = '$99';
+      document.getElementById('bundle-buy-btn').textContent = 'Get Complete Bundle \u2014 $99';
+      document.getElementById('bundle-savings').textContent = 'Save $63 vs. buying separately ($162)';
+
+      // Remove strikethrough prices
+      document.querySelectorAll('.promo-original-price').forEach(el => el.remove());
+
+      // Reset addon prices
+      document.querySelectorAll('.addon-price').forEach(el => {
+        el.textContent = '$19';
+      });
+      document.querySelectorAll('.addon-original-price').forEach(el => el.remove());
+
+      // Hide package deal
+      document.getElementById('package-deal-section').classList.add('hidden');
+    }
+
+    function applyDiscountUI(promo) {
+      const pct = promo.discount_percent;
+      const fixedCents = promo.discount_amount_cents;
+
+      function discountedPrice(originalCents) {
+        if (pct) return Math.round(originalCents * (1 - pct / 100));
+        if (fixedCents) return Math.max(0, originalCents - fixedCents);
+        return originalCents;
+      }
+
+      function formatPrice(cents) {
+        return '$' + (cents / 100).toFixed(cents % 100 === 0 ? 0 : 2);
+      }
+
+      // Base package
+      const baseNew = discountedPrice(2900);
+      const basePriceEl = document.getElementById('base-price');
+      basePriceEl.textContent = formatPrice(baseNew);
+      addStrikethrough(basePriceEl.parentElement, '$29');
+      document.getElementById('base-buy-btn').textContent = `Get Started \u2014 ${formatPrice(baseNew)}`;
+
+      // Bundle
+      const bundleNew = discountedPrice(9900);
+      const bundlePriceEl = document.getElementById('bundle-price');
+      bundlePriceEl.textContent = formatPrice(bundleNew);
+      addStrikethrough(bundlePriceEl.parentElement, '$99');
+      document.getElementById('bundle-buy-btn').textContent = `Get Complete Bundle \u2014 ${formatPrice(bundleNew)}`;
+      document.getElementById('bundle-savings').textContent =
+        `Save ${formatPrice(16200 - bundleNew)} vs. buying separately ($162)`;
+
+      // Addons
+      document.querySelectorAll('.addon-price').forEach(el => {
+        const addonNew = discountedPrice(1900);
+        el.textContent = formatPrice(addonNew);
+        addStrikethrough(el.parentElement, '$19', 'addon-original-price');
+      });
+    }
+
+    function addStrikethrough(container, originalText, extraClass) {
+      // Don't add duplicate
+      if (container.querySelector('.promo-original-price, .addon-original-price')) return;
+      const span = document.createElement('span');
+      span.className = `text-lg text-gray-500 line-through mr-2 font-mono ${extraClass || 'promo-original-price'}`;
+      span.textContent = originalText;
+      container.prepend(span);
+    }
+
+    function applyPackageUI(promo) {
+      const section = document.getElementById('package-deal-section');
+      section.classList.remove('hidden');
+
+      document.getElementById('package-deal-title').textContent = promo.description || promo.code;
+      document.getElementById('package-deal-desc').textContent = `Code: ${promo.code}`;
+      document.getElementById('package-deal-price').textContent =
+        '$' + (promo.package_price_cents / 100).toFixed(promo.package_price_cents % 100 === 0 ? 0 : 2);
+
+      const modules = (promo.package_modules || [])
+        .map(m => m.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()))
+        .join(', ');
+      document.getElementById('package-deal-modules').textContent = `Includes: ${modules}`;
+
+      // Scroll into view
+      section.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    // ── Checkout ──
+    let checkoutInProgress = false;
+
+    async function createCheckout(productType, moduleName) {
+      if (checkoutInProgress) return;
+      checkoutInProgress = true;
+
+      // Disable all buy buttons and show loading
+      const allBuyBtns = document.querySelectorAll('#base-buy-btn, #bundle-buy-btn, #package-deal-btn, .addon-buy-btn');
+      const originalTexts = new Map();
+      allBuyBtns.forEach(btn => {
+        originalTexts.set(btn, btn.textContent);
+        btn.disabled = true;
+      });
+
+      // Show loading on the clicked button category
+      const clickedBtns = productType === 'bundle'
+        ? [document.getElementById('bundle-buy-btn')]
+        : productType === 'addon' && moduleName
+          ? [...document.querySelectorAll(`.addon-buy-btn[data-module="${moduleName}"]`)]
+          : [document.getElementById('base-buy-btn')];
+      clickedBtns.forEach(btn => { if (btn) btn.textContent = 'Redirecting...'; });
+
+      const body = { product_type: productType };
+      if (moduleName) body.module = moduleName;
+      if (activePromo) body.promo_code = activePromo.code;
+
+      try {
+        const data = await callEdgeFunction('create-checkout-session', body);
+        if (data.url) {
+          window.location.href = data.url;
+          return; // keep buttons disabled during redirect
+        }
+        showCheckoutError(data.error || 'Failed to start checkout. Please try again.');
+      } catch {
+        showCheckoutError('Failed to start checkout. Please try again.');
+      }
+
+      // Restore buttons on error
+      allBuyBtns.forEach(btn => {
+        btn.textContent = originalTexts.get(btn);
+        btn.disabled = false;
+      });
+      checkoutInProgress = false;
+    }
+
+    function showCheckoutError(message) {
+      // Show error near the promo result area (visible on page)
+      const result = document.getElementById('promo-result');
+      result.classList.remove('hidden');
+      result.className = 'mt-3 text-sm text-center text-red-400';
+      result.textContent = message;
+      result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    // ── Wire up buttons ──
+    document.addEventListener('DOMContentLoaded', () => {
+      // Promo input
+      document.getElementById('promo-apply-btn').addEventListener('click', validatePromo);
+      document.getElementById('promo-input').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') validatePromo();
+      });
+
+      // Base package buy
+      document.getElementById('base-buy-btn').addEventListener('click', () => {
+        const mod = document.getElementById('base-module-select').value;
+        createCheckout('base', mod);
+      });
+
+      // Bundle buy
+      document.getElementById('bundle-buy-btn').addEventListener('click', () => {
+        createCheckout('bundle');
+      });
+
+      // Package deal buy
+      document.getElementById('package-deal-btn').addEventListener('click', () => {
+        createCheckout('bundle'); // package promos go through the checkout with promo_code set
+      });
+
+      // Add-on buttons
+      document.querySelectorAll('.addon-buy-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          createCheckout(btn.dataset.productType, btn.dataset.module);
+        });
+      });
+    });
+  </script>
 
 </BaseLayout>

--- a/tests/pricing.spec.ts
+++ b/tests/pricing.spec.ts
@@ -46,14 +46,12 @@ test.describe('Pricing Page - Dark Terminal Theme', () => {
     expect(className).toContain('text-green-400');
   });
 
-  test('should have working Stripe links on pricing cards', async ({ page }) => {
-    const buyButtons = page.getByRole('link', { name: /Get Started|Get Complete Bundle/ });
+  test('should have buy buttons on pricing cards', async ({ page }) => {
+    const baseBuy = page.getByRole('button', { name: /Get Started/ });
+    const bundleBuy = page.getByRole('button', { name: /Get Complete Bundle/ });
 
-    for (const button of await buyButtons.all()) {
-      const href = await button.getAttribute('href');
-      expect(href).toContain('buy.stripe.com');
-      expect(href).not.toContain('test_');
-    }
+    await expect(baseBuy).toBeVisible();
+    await expect(bundleBuy).toBeVisible();
   });
 
   test('should display all 7 add-on modules', async ({ page }) => {
@@ -80,18 +78,13 @@ test.describe('Pricing Page - Dark Terminal Theme', () => {
     await expect(modulePrice).toBeVisible();
   });
 
-  test('should have Stripe links on all add-on modules', async ({ page }) => {
+  test('should have buy buttons on all add-on modules', async ({ page }) => {
     await page.getByRole('heading', { name: /Add-on Modules/i }).scrollIntoViewIfNeeded();
 
-    const addButtons = page.getByRole('link', { name: /Add Module/i });
+    const addButtons = page.getByRole('button', { name: /Add Module/i });
     const count = await addButtons.count();
 
-    expect(count).toBe(7); // Should have 7 add-on modules
-
-    for (const button of await addButtons.all()) {
-      const href = await button.getAttribute('href');
-      expect(href).toContain('buy.stripe.com');
-    }
+    expect(count).toBe(7);
   });
 
   test('should display colored icon backgrounds for modules', async ({ page }) => {
@@ -155,5 +148,22 @@ test.describe('Pricing Page - Dark Terminal Theme', () => {
     const moduleCard = main.locator('.bg-gray-900\\/50').first();
     const className = await moduleCard.getAttribute('class');
     expect(className).toContain('hover:border-green-700');
+  });
+
+  test('should display promo code input', async ({ page }) => {
+    const promoInput = page.locator('#promo-input');
+    const applyBtn = page.getByRole('button', { name: 'Apply' });
+
+    await expect(promoInput).toBeVisible();
+    await expect(applyBtn).toBeVisible();
+  });
+
+  test('should have module selector dropdown', async ({ page }) => {
+    const select = page.locator('#base-module-select');
+    await expect(select).toBeVisible();
+
+    const options = select.locator('option');
+    const count = await options.count();
+    expect(count).toBe(7);
   });
 });

--- a/tests/promo-code.spec.ts
+++ b/tests/promo-code.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Promo Code UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/pricing');
+  });
+
+  test('should display promo code input and Apply button', async ({ page }) => {
+    const promoInput = page.locator('#promo-input');
+    const applyBtn = page.getByRole('button', { name: 'Apply' });
+
+    await expect(promoInput).toBeVisible();
+    await expect(applyBtn).toBeVisible();
+    await expect(promoInput).toHaveAttribute('placeholder', 'Enter code');
+  });
+
+  test('promo input should accept text', async ({ page }) => {
+    const promoInput = page.locator('#promo-input');
+    await promoInput.fill('TESTCODE');
+    await expect(promoInput).toHaveValue('TESTCODE');
+  });
+
+  test('promo input should have uppercase styling', async ({ page }) => {
+    const promoInput = page.locator('#promo-input');
+    const className = await promoInput.getAttribute('class');
+    expect(className).toContain('uppercase');
+    expect(className).toContain('font-mono');
+  });
+
+  test('Apply button should show error for invalid code', async ({ page }) => {
+    // Mock the validate-promo endpoint to return an error
+    await page.route('**/functions/v1/validate-promo', route => {
+      route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ valid: false, error: 'Promo code not found.' }),
+      });
+    });
+
+    const promoInput = page.locator('#promo-input');
+    await promoInput.fill('BADCODE');
+    await page.getByRole('button', { name: 'Apply' }).click();
+
+    const result = page.locator('#promo-result');
+    await expect(result).toBeVisible();
+    await expect(result).toHaveClass(/text-red-400/);
+    await expect(result).toContainText('Promo code not found');
+  });
+
+  test('Apply button should show success for valid discount code', async ({ page }) => {
+    await page.route('**/functions/v1/validate-promo', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          valid: true,
+          promo_type: 'discount',
+          code: 'SAVE20',
+          description: '20% off',
+          discount_percent: 20,
+          discount_amount_cents: null,
+        }),
+      });
+    });
+
+    const promoInput = page.locator('#promo-input');
+    await promoInput.fill('SAVE20');
+    await page.getByRole('button', { name: 'Apply' }).click();
+
+    const result = page.locator('#promo-result');
+    await expect(result).toBeVisible();
+    await expect(result).toHaveClass(/text-green-400/);
+    await expect(result).toContainText('SAVE20 applied');
+    await expect(result).toContainText('20% off');
+  });
+
+  test('discount promo should show strikethrough prices', async ({ page }) => {
+    await page.route('**/functions/v1/validate-promo', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          valid: true,
+          promo_type: 'discount',
+          code: 'HALF',
+          discount_percent: 50,
+          discount_amount_cents: null,
+        }),
+      });
+    });
+
+    await page.locator('#promo-input').fill('HALF');
+    await page.getByRole('button', { name: 'Apply' }).click();
+
+    // Wait for the promo result to appear
+    await expect(page.locator('#promo-result')).toBeVisible();
+
+    // Strikethrough original prices should appear
+    const strikethroughs = page.locator('.promo-original-price');
+    const count = await strikethroughs.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('package promo should show package deal card', async ({ page }) => {
+    await page.route('**/functions/v1/validate-promo', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          valid: true,
+          promo_type: 'package',
+          code: 'TECHBUNDLE',
+          description: 'Tech Writer Bundle',
+          package_modules: ['seo_writer', 'tech_docs', 'academic'],
+          package_price_cents: 4900,
+          package_product_type: 'addon',
+        }),
+      });
+    });
+
+    await page.locator('#promo-input').fill('TECHBUNDLE');
+    await page.getByRole('button', { name: 'Apply' }).click();
+
+    const packageSection = page.locator('#package-deal-section');
+    await expect(packageSection).toBeVisible();
+    await expect(page.locator('#package-deal-price')).toContainText('$49');
+    await expect(page.locator('#package-deal-modules')).toContainText('Seo Writer');
+  });
+
+  test('package deal section should be hidden by default', async ({ page }) => {
+    const packageSection = page.locator('#package-deal-section');
+    await expect(packageSection).toBeHidden();
+  });
+
+  test('buy buttons should be buttons, not links', async ({ page }) => {
+    const baseBuy = page.locator('#base-buy-btn');
+    const bundleBuy = page.locator('#bundle-buy-btn');
+
+    await expect(baseBuy).toHaveAttribute('type', 'button');
+    await expect(bundleBuy).toHaveAttribute('type', 'button');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace static Stripe Payment Links with dynamic Checkout Sessions via Supabase edge functions (`validate-promo`, `create-checkout-session`)
- Add promo code input bar on pricing page with real-time validation
- Support discount codes (percentage/fixed amount off) and package codes (custom module bundles at special prices)
- Update stripe-webhook to track promo redemptions and record discounts on purchases
- Add 9 new promo-code E2E tests and update existing pricing tests for button-based checkout

Closes wallco26/workinprivate#281

## Test plan
- [x] 140 pricing + promo tests pass across 5 browser targets
- [x] validate-promo edge function verified via curl (valid + invalid codes)
- [x] create-checkout-session edge function deployed with all 15 STRIPE_PRICE_* secrets set
- [x] stripe-webhook updated to handle promo metadata and redemption tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)