### PR TITLE
Add Google Analytics (GA4) tracking

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -117,6 +117,15 @@ const isPreview = import.meta.env.PUBLIC_SITE_PREVIEW !== 'false';
       "itemListElement": breadcrumbItems
     })} />
 
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-DSRFQPEBMS"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-DSRFQPEBMS');
+    </script>
+
     <!-- Google Fonts - Source Sans 3 & Merriweather -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -68,7 +68,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </li>
             </ul>
 
-            <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
+            <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 39.00, items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 39.00, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
               Buy Now — $39
             </a>
 

--- a/src/pages/purchase-success.astro
+++ b/src/pages/purchase-success.astro
@@ -143,4 +143,21 @@ const baseUrl = 'https://github.com/wallco26/workinprivate-site/releases/latest/
     </div>
   </section>
 
+  <!-- Google Analytics: track purchase conversion -->
+  <script is:inline>
+    if (typeof gtag === 'function') {
+      gtag('event', 'purchase', {
+        transaction_id: new URLSearchParams(window.location.search).get('session_id') || ('wip_' + Date.now()),
+        value: 39.00,
+        currency: 'USD',
+        items: [{
+          item_id: 'workinprivate',
+          item_name: 'WorkInPrivate',
+          price: 39.00,
+          quantity: 1
+        }]
+      });
+    }
+  </script>
+
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Add GA4 tracking snippet (G-DSRFQPEBMS) to BaseLayout for site-wide pageview, traffic source, and geography tracking
- Add `begin_checkout` event on the Stripe "Buy Now" button click on the pricing page
- Add `purchase` conversion event on the purchase-success page, using Stripe's `session_id` for transaction deduplication

## Test plan
- [ ] Verify GA4 real-time reports show pageviews after deploy
- [ ] Click "Buy Now" on pricing page and confirm `begin_checkout` event appears in GA4
- [ ] Visit `/purchase-success` and confirm `purchase` event appears in GA4
- [ ] Mark `purchase` as a key event in GA4 once it becomes available

https://claude.ai/code/session_01NTCst94VHzj8pno4EYRADd