### PR TITLE
Remove 30-day money-back guarantee mentions site-wide

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -67,14 +67,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       },
       {
         "@type": "Question",
-        "name": "Is there a money-back guarantee?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. If you're not happy for any reason, contact us within 30 days for a full refund. No questions asked."
-        }
-      },
-      {
-        "@type": "Question",
         "name": "Do I need technical skills?",
         "acceptedAnswer": {
           "@type": "Answer",
@@ -175,16 +167,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </summary>
           <div class="px-6 pb-5 text-[#5A6474] text-sm leading-relaxed">
             Yes! You can upload PDFs, Word documents, text files, code files, and images. The AI reads the content and helps you analyze, summarize, or work with it. For images, you'll need a vision-capable model (the app will recommend one if needed).
-          </div>
-        </details>
-
-        <details class="group bg-[#F7F9FC] border-2 border-[#E2E8F0] rounded-xl overflow-hidden hover:border-[#D4E3F5] transition-colors">
-          <summary class="flex items-center justify-between cursor-pointer px-6 py-5 font-bold text-[#1B3A5C] text-base">
-            Is there a money-back guarantee?
-            <svg class="w-5 h-5 text-[#4B8BD4] group-open:rotate-180 transition-transform flex-shrink-0 ml-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6,9 12,15 18,9"/></svg>
-          </summary>
-          <div class="px-6 pb-5 text-[#5A6474] text-sm leading-relaxed">
-            Yes. If you're not happy for any reason, contact us within 30 days for a full refund. No questions asked.
           </div>
         </details>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,10 +54,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               See How It Works
             </a>
           </div>
-          <div class="flex items-center gap-2.5 bg-[#FEFCBF] text-yellow-900 px-4 py-3 rounded-lg border border-[#ECC94B] text-sm font-semibold" style="animation: fadeUp 0.5s ease 0.4s both;">
-            <svg class="w-5 h-5 text-[#D69E2E] flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-            <strong>30-day money-back guarantee — no questions asked.</strong>
-          </div>
         </div>
         <!-- Chat UI Preview -->
         <div class="max-w-md mx-auto w-full">
@@ -328,7 +324,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           Buy Now — $39
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
-        <p class="text-[#8A9AB5] text-sm mt-4">30-day money-back guarantee. Works on Windows, macOS, and Linux.</p>
+        <p class="text-[#8A9AB5] text-sm mt-4">Works on Windows, macOS, and Linux.</p>
       </div>
     </div>
   </section>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -72,7 +72,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               Buy Now — $39
             </a>
 
-            <p class="text-center text-[#8A9AB5] text-sm mt-4">30-day money-back guarantee</p>
           </div>
         </div>
       </div>

--- a/src/pages/purchase-cancel.astro
+++ b/src/pages/purchase-cancel.astro
@@ -44,10 +44,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-[#38A169] mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-              <span class="text-[#5A6474] text-sm">30-day money-back guarantee — no questions asked</span>
-            </li>
-            <li class="flex items-start gap-3">
-              <svg class="w-5 h-5 text-[#38A169] mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               <span class="text-[#5A6474] text-sm">100% local — your content never leaves your machine</span>
             </li>
           </ul>

--- a/src/pages/refund.astro
+++ b/src/pages/refund.astro
@@ -2,48 +2,46 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Refund Policy - WorkInPrivate" description="Refund Policy for WorkInPrivate — 30-day money-back guarantee on all purchases.">
+<BaseLayout title="Refund Policy - WorkInPrivate" description="Refund Policy for WorkInPrivate — all sales are final, with limited exceptions.">
 
   <section class="py-16 sm:py-20 bg-white">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-3xl mx-auto prose prose-gray prose-indigo">
         <h1 class="text-4xl font-bold text-gray-900 mb-2">Refund Policy</h1>
-        <p class="text-sm text-gray-500 mb-10">Last updated: February 22, 2026</p>
+        <p class="text-sm text-gray-500 mb-10">Last updated: April 22, 2026</p>
 
-        <p>We want you to be satisfied with your purchase of WorkInPrivate. This Refund Policy explains the terms under which you may request a refund.</p>
+        <p>This Refund Policy explains the terms under which you may request a refund for WorkInPrivate.</p>
 
         <div class="bg-indigo-50 rounded-xl p-6 not-prose mb-6">
-          <p class="font-semibold text-gray-900 mb-2">30-Day Money-Back Guarantee</p>
-          <p class="text-gray-700">If WorkInPrivate does not meet your expectations, you may request a full refund within 30 days of your purchase date. No questions asked.</p>
+          <p class="font-semibold text-gray-900 mb-2">All Sales Are Final</p>
+          <p class="text-gray-700">WorkInPrivate is sold as-is. All purchases are final and non-refundable, except in the limited circumstances described below.</p>
         </div>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">1. Refund Window</h2>
-        <p>You may request a full refund within <strong>30 days</strong> of your original purchase date. The purchase date is the date the payment was successfully processed, as shown on your email receipt.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">1. Try Before You Buy</h2>
+        <p>We strongly encourage you to review the product description, system requirements, and FAQ before purchasing. Because WorkInPrivate runs locally on your computer and we cannot revoke downloaded software, refunds are not offered as a general policy.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. What Can Be Refunded</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">2. Limited Exceptions</h2>
+        <p>At our sole discretion, we may issue a refund in exceptional cases, including:</p>
         <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Base application</strong> — Full refund within 30 days</li>
-          <li><strong>Individual modules</strong> — Full refund of the module price within 30 days</li>
-          <li><strong>Bundles</strong> — Full refund of the bundle price within 30 days</li>
+          <li><strong>Duplicate purchases</strong> — if you were accidentally charged more than once for the same product</li>
+          <li><strong>Unauthorized charges</strong> — if a purchase was made without your authorization</li>
+          <li><strong>Technical issues we cannot resolve</strong> — if the software fails to function on a supported system and our support team is unable to provide a fix</li>
         </ul>
-        <p>Bundles are refunded as a whole. Partial refunds for individual modules within a bundle are not available. Individual module purchases may be refunded separately without affecting your base application license or other module licenses.</p>
-
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. Non-Refundable Scenarios</h2>
         <p>Refunds will <strong>not</strong> be granted if:</p>
         <ul class="list-disc pl-6 space-y-2">
-          <li>The request is made after the 30-day window has passed</li>
+          <li>You changed your mind after purchase</li>
+          <li>Your hardware does not meet the published system requirements</li>
           <li>Your license has been terminated due to a violation of the <a href="/terms" class="text-indigo-600 hover:text-indigo-700">Terms of Sale</a> or <a href="/license" class="text-indigo-600 hover:text-indigo-700">License Agreement</a></li>
           <li>You have shared or redistributed your license key</li>
         </ul>
-        <p>If you purchased the wrong OS version, see Section 6 (Exchanges) instead of requesting a refund.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. How to Request a Refund</h2>
-        <p>To request a refund, email us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a> with:</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">3. How to Request a Refund</h2>
+        <p>If you believe your situation qualifies under Section 2, email us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a> with:</p>
         <ul class="list-disc pl-6 space-y-2">
           <li>Subject line: "Refund Request"</li>
           <li>Your email address used for the purchase</li>
           <li>Order confirmation number or Stripe transaction ID</li>
-          <li>Reason for the refund (optional, but helps us improve)</li>
+          <li>A description of the issue</li>
         </ul>
 
         <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Processing Time</h3>
@@ -53,35 +51,24 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <li>The refund will appear on your statement within <strong>5–10 business days</strong> after processing, depending on your financial institution</li>
         </ul>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. What Happens After a Refund</h2>
-
-        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Full Refund (Base Application or Bundle)</h3>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">4. What Happens After a Refund</h2>
         <ul class="list-disc pl-6 space-y-2">
           <li>Your license key will be deactivated</li>
-          <li>All associated module licenses will be removed</li>
           <li>You must uninstall all copies of WorkInPrivate from your devices</li>
           <li>You will no longer have access to software updates or support</li>
         </ul>
-
-        <h3 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Module-Only Refund</h3>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>The refunded module will be removed from your account</li>
-          <li>Your base application license and other module licenses remain active</li>
-          <li>You retain access to all non-refunded products</li>
-        </ul>
-
         <p class="mt-4">All refunds are issued to the original payment method via Stripe. We do not issue refunds by check, cash, or alternative payment methods.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">6. Exchanges</h2>
-        <p>If you purchased the wrong OS version (e.g., Windows instead of macOS), contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a> within 30 days. We will exchange your license for the correct platform at no additional cost.</p>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">5. Exchanges</h2>
+        <p>If you purchased the wrong OS version (e.g., Windows instead of macOS), contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>. We will exchange your license for the correct platform at no additional cost.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. Disputes</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">6. Disputes</h2>
         <p>If your refund request is denied and you believe this is in error, reply to our denial email with additional information. We will review your case within 5 business days and provide a final decision. We encourage resolving disputes directly with us before contacting your payment provider.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Changes to This Policy</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">7. Changes to This Policy</h2>
         <p>We may update this Refund Policy from time to time. Changes will be posted on this page with an updated date. The refund terms in effect at the time of your purchase will apply to that purchase.</p>
 
-        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">9. Contact</h2>
+        <h2 class="text-2xl font-semibold text-gray-900 mt-10 mb-4">8. Contact</h2>
         <p>For refund requests or questions about this policy, contact us at <a href="mailto:support@workinprivate.com" class="text-indigo-600 hover:text-indigo-700">support@workinprivate.com</a>.</p>
       </div>
     </div>

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -58,11 +58,6 @@ test.describe('Homepage - Friendly Neighbor Light Theme', () => {
     await expect(badge).toBeVisible();
   });
 
-  test('should display money-back guarantee in hero', async ({ page }) => {
-    const guarantee = page.locator('text=30-day money-back guarantee').first();
-    await expect(guarantee).toBeVisible();
-  });
-
   test('should display blue CTA button in hero', async ({ page }) => {
     const buyButton = page.getByRole('link', { name: /Start Writing Today.*\$29/i }).first();
     await expect(buyButton).toBeVisible();

--- a/tests/pricing.spec.ts
+++ b/tests/pricing.spec.ts
@@ -126,11 +126,6 @@ test.describe('Pricing Page', () => {
     await expect(setupNotice).toBeVisible();
   });
 
-  test('should display money-back guarantee badge', async ({ page }) => {
-    const guarantee = page.locator('text=30-day money-back guarantee on all purchases').first();
-    await expect(guarantee).toBeVisible();
-  });
-
   test('should have hover states on add-on modules', async ({ page }) => {
     await page.getByRole('heading', { name: /Add-on Writing Modules/i }).scrollIntoViewIfNeeded();
 


### PR DESCRIPTION
Drops the guarantee badge and copy from the home page hero and CTA,
pricing page, purchase-cancel reassurance list, and FAQ. Rewrites the
refund policy to state all sales are final, with limited exceptions
(duplicate charges, unauthorized charges, unresolvable technical
issues) at our discretion, and keeps the OS-version exchange path.
Removes the two Playwright assertions that looked for the guarantee
text so the suite no longer fails on content that no longer exists.

https://claude.ai/code/session_01FRX5ByBXRmDjZFh2YTgoZ2