### PR TITLE
Reduce product price from $39 to $14.99

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Marketing website for **WorkInPrivate** — a private AI chatbot that runs locally via Ollama. Hosted on GitHub Pages at `www.workinprivate.com`. Sells the product ($39 one-time) built in the sibling `workinprivate/` repo.
+Marketing website for **WorkInPrivate** — a private AI chatbot that runs locally via Ollama. Hosted on GitHub Pages at `www.workinprivate.com`. Sells the product ($14.99 one-time) built in the sibling `workinprivate/` repo.
 
 **Product positioning:** "Your private AI chatbot — runs 100% on your computer. No cloud. No accounts. Just you."
 
@@ -51,8 +51,8 @@ Fonts: Source Sans 3 (body), Merriweather (headings), JetBrains Mono (code).
 - All pages use `BaseLayout` and pass `title` and `description` props for SEO
 - Styling is inline Tailwind utility classes — no separate CSS files
 - The site is fully static (`output: 'static'`)
-- Pricing: single product at $39 one-time (no modules, no subscriptions)
-- Primary CTA: "Buy Now — $39" linking to `/pricing`
+- Pricing: single product at $14.99 one-time (no modules, no subscriptions)
+- Primary CTA: "Buy Now — $14.99" linking to `/pricing`
 
 ## Testing
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -38,7 +38,7 @@
           </li>
         </ul>
         <a href="/pricing" class="inline-flex items-center px-5 py-2.5 text-sm font-bold rounded-[10px] text-white bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-colors shadow-sm no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
-          Buy Now — $39
+          Buy Now — $14.99
         </a>
       </div>
 
@@ -70,7 +70,7 @@
           FAQ
         </a>
         <a href="/pricing" class="mt-2 text-center text-white bg-[#4B8BD4] hover:bg-[#2E6BB5] block px-3 py-2.5 rounded-[10px] text-base font-bold transition-colors no-underline" style="text-decoration: none;">
-          Buy Now — $39
+          Buy Now — $14.99
         </a>
       </div>
     </div>

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -10,7 +10,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <h1 class="font-serif text-4xl sm:text-5xl font-bold text-[#1B3A5C] mb-4">Download WorkInPrivate</h1>
       <p class="text-xl text-[#5A6474] max-w-2xl mx-auto mb-8">Purchase WorkInPrivate to get instant download access for Windows, macOS, and Linux.</p>
       <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
-        Buy Now — $39
+        Buy Now — $14.99
       </a>
       <p class="text-[#8A9AB5] text-sm mt-4">One-time payment. Download links provided immediately after purchase.</p>
     </div>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -22,7 +22,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         "name": "How is this different from ChatGPT?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "The main difference is privacy and cost. ChatGPT sends everything you type to OpenAI's servers and costs $20/month. WorkInPrivate runs the AI on your own computer — your conversations never leave your machine. And it's a one-time purchase ($39), not a subscription."
+          "text": "The main difference is privacy and cost. ChatGPT sends everything you type to OpenAI's servers and costs $20/month. WorkInPrivate runs the AI on your own computer — your conversations never leave your machine. And it's a one-time purchase ($14.99), not a subscription."
         }
       },
       {
@@ -114,7 +114,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <svg class="w-5 h-5 text-[#4B8BD4] group-open:rotate-180 transition-transform flex-shrink-0 ml-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6,9 12,15 18,9"/></svg>
           </summary>
           <div class="px-6 pb-5 text-[#5A6474] text-sm leading-relaxed">
-            The main difference is privacy and cost. ChatGPT sends everything you type to OpenAI's servers and costs $20/month. WorkInPrivate runs the AI on your own computer — your conversations never leave your machine. And it's a one-time purchase ($39), not a subscription.
+            The main difference is privacy and cost. ChatGPT sends everything you type to OpenAI's servers and costs $20/month. WorkInPrivate runs the AI on your own computer — your conversations never leave your machine. And it's a one-time purchase ($14.99), not a subscription.
           </div>
         </details>
 
@@ -200,7 +200,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <h2 class="font-serif text-2xl font-bold text-[#1B3A5C] mb-4">Still have questions?</h2>
       <p class="text-[#5A6474] mb-6">We're happy to help. Reach out any time.</p>
       <a href="/pricing" class="inline-flex items-center gap-2.5 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
-        Get WorkInPrivate — $39
+        Get WorkInPrivate — $14.99
       </a>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     "operatingSystem": "Windows, macOS, Linux",
     "offers": {
       "@type": "Offer",
-      "price": "39.00",
+      "price": "14.99",
       "priceCurrency": "USD",
       "availability": "https://schema.org/InStock"
     },
@@ -47,7 +47,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </p>
           <div class="flex flex-wrap gap-4 mb-7" style="animation: fadeUp 0.5s ease 0.3s both;">
             <a href="/pricing" class="inline-flex items-center gap-2.5 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
-              Buy Now — $39
+              Buy Now — $14.99
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
             </a>
             <a href="#how-it-works" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-[#2E6BB5] font-bold text-lg bg-[#EDF2FA] hover:bg-[#D4E3F5] border-2 border-[#D4E3F5] hover:border-[#4B8BD4] transition-all no-underline" style="text-decoration: none;">
@@ -104,7 +104,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">What Is This?</div>
         <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5 leading-tight">Like ChatGPT, But On Your Computer</h2>
         <p class="text-lg text-[#5A6474] leading-relaxed">
-          You've probably used ChatGPT or Claude. They're great, but they cost $20+ per month and send everything you type to the cloud. WorkInPrivate gives you the same chat experience, but everything runs right on your computer. Pay once ($39), and it's yours forever. No monthly bills. No data collection. No one reading your conversations.
+          You've probably used ChatGPT or Claude. They're great, but they cost $20+ per month and send everything you type to the cloud. WorkInPrivate gives you the same chat experience, but everything runs right on your computer. Pay once ($14.99), and it's yours forever. No monthly bills. No data collection. No one reading your conversations.
         </p>
       </div>
     </div>
@@ -191,7 +191,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </div>
           <div>
             <h3 class="font-bold text-[#1B3A5C] text-base mb-1">One-Time Purchase</h3>
-            <p class="text-[#5A6474] text-sm leading-relaxed">$39 once. No subscription, no usage limits, no surprises on your credit card. Use it as much as you want, forever.</p>
+            <p class="text-[#5A6474] text-sm leading-relaxed">$14.99 once. No subscription, no usage limits, no surprises on your credit card. Use it as much as you want, forever.</p>
           </div>
         </div>
         <div class="bg-white border-2 border-[#E2E8F0] rounded-xl p-7 flex gap-4 hover:border-[#D4E3F5] transition-colors">
@@ -231,7 +231,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               <th class="py-4 px-4 text-[#1B3A5C] font-bold"></th>
               <th class="py-4 px-4 text-center">
                 <div class="font-bold text-[#4B8BD4]">WorkInPrivate</div>
-                <div class="text-xs text-[#5A6474]">$39 one-time</div>
+                <div class="text-xs text-[#5A6474]">$14.99 one-time</div>
               </th>
               <th class="py-4 px-4 text-center">
                 <div class="font-bold text-[#5A6474]">ChatGPT Plus</div>
@@ -264,7 +264,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </tr>
             <tr class="border-b border-[#E2E8F0]">
               <td class="py-3 px-4 text-[#5A6474]">Cost after 1 year</td>
-              <td class="py-3 px-4 text-center text-[#38A169] font-bold">$39</td>
+              <td class="py-3 px-4 text-center text-[#38A169] font-bold">$14.99</td>
               <td class="py-3 px-4 text-center text-[#5A6474]">$240</td>
               <td class="py-3 px-4 text-center text-[#5A6474]">$240</td>
             </tr>
@@ -321,7 +321,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5">Ready for a Private AI?</h2>
         <p class="text-lg text-[#5A6474] mb-8">Stop paying monthly subscriptions. Stop sending your data to the cloud. Get WorkInPrivate and own your AI experience.</p>
         <a href="/pricing" class="inline-flex items-center gap-2.5 px-10 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
-          Buy Now — $39
+          Buy Now — $14.99
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
         <p class="text-[#8A9AB5] text-sm mt-4">Works on Windows, macOS, and Linux.</p>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Pricing - WorkInPrivate" description="Get WorkInPrivate for $39 one-time. No subscriptions, no API costs, no usage limits. Your private AI chatbot, forever.">
+<BaseLayout title="Pricing - WorkInPrivate" description="Get WorkInPrivate for $14.99 one-time. No subscriptions, no API costs, no usage limits. Your private AI chatbot, forever.">
 
   <!-- Pricing Hero -->
   <section class="py-16 sm:py-20 bg-gradient-to-b from-white to-[#F7F9FC]">
@@ -26,7 +26,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <h2 class="font-serif text-2xl font-bold mb-2">WorkInPrivate</h2>
             <p class="text-[#D4E3F5] text-sm">Your private AI chatbot</p>
             <div class="mt-4">
-              <span class="text-5xl font-bold">$39</span>
+              <span class="text-5xl font-bold">$14.99</span>
               <span class="text-[#D4E3F5] text-lg ml-2">one-time</span>
             </div>
           </div>
@@ -68,8 +68,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </li>
             </ul>
 
-            <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 39.00, items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 39.00, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
-              Buy Now — $39
+            <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
+              Buy Now — $14.99
             </a>
 
           </div>
@@ -87,7 +87,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </div>
       <div class="max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-3 gap-6 text-center">
         <div class="bg-[#F7F9FC] border-2 border-[#E2E8F0] rounded-xl p-6">
-          <div class="text-3xl font-bold text-[#4B8BD4] mb-2">$39</div>
+          <div class="text-3xl font-bold text-[#4B8BD4] mb-2">$14.99</div>
           <div class="text-sm text-[#5A6474] font-semibold">WorkInPrivate</div>
           <div class="text-xs text-[#8A9AB5] mt-1">One-time, forever</div>
         </div>

--- a/src/pages/purchase-success.astro
+++ b/src/pages/purchase-success.astro
@@ -150,12 +150,12 @@ const baseUrl = 'https://github.com/wallco26/workinprivate-site/releases/latest/
       if (sessionId && sessionId.startsWith('cs_')) {
         gtag('event', 'purchase', {
           transaction_id: sessionId,
-          value: 39.00,
+          value: 14.99,
           currency: 'USD',
           items: [{
             item_id: 'workinprivate',
             item_name: 'WorkInPrivate',
-            price: 39.00,
+            price: 14.99,
             quantity: 1
           }]
         });


### PR DESCRIPTION
Updates the product price from **$39** to **$14.99** across the site.

## Changes
- **`pricing.astro`** — price card, page SEO description, side-card price, and `begin_checkout` analytics event values
- **`index.astro`** — hero/footer CTAs, JSON-LD `price`, comparison table, and inline copy
- **`Header.astro`** — desktop and mobile "Buy Now" buttons
- **`download.astro`** — "Buy Now" button
- **`faq.astro`** — FAQ answer text + JSON-LD, and the bottom CTA
- **`purchase-success.astro`** — GA `purchase` event `value`/`price`
- **`CLAUDE.md`** — project docs kept in sync

## Notes
- The Stripe payment link is unchanged — the actual charge amount is configured in the Stripe dashboard and should be updated there to match.
- `npm run build` passes (12 pages built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrWA4cj3NqqX7pXiWMUdEr)_