### PR TITLE
Update checkout links to new $14.99 Stripe Payment Link

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h1 class="font-serif text-4xl sm:text-5xl font-bold text-[#1B3A5C] mb-4">Download WorkInPrivate</h1>
       <p class="text-xl text-[#5A6474] max-w-2xl mx-auto mb-8">Purchase WorkInPrivate to get instant download access for Windows, macOS, and Linux.</p>
-      <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
+      <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
         Buy Now — $14.99
       </a>
       <p class="text-[#8A9AB5] text-sm mt-4">One-time payment. Download links provided immediately after purchase.</p>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -68,7 +68,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </li>
             </ul>
 
-            <a href="https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
+            <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
               Buy Now — $14.99
             </a>
 


### PR DESCRIPTION
Replaces the old Stripe Payment Link (which charged **$39**) with the new link tied to the **$14.99** price.

## Changes
- **`pricing.astro`** — checkout button `href` → new Payment Link
- **`download.astro`** — checkout button `href` → new Payment Link

Old: `https://buy.stripe.com/4gM9ATfo15Li8eX9PDaR20g`
New: `https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p`

`npm run build` passes (12 pages built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrWA4cj3NqqX7pXiWMUdEr)_