### PR TITLE
Fix analytics funnel gap on download page

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h1 class="font-serif text-4xl sm:text-5xl font-bold text-[#1B3A5C] mb-4">Download WorkInPrivate</h1>
       <p class="text-xl text-[#5A6474] max-w-2xl mx-auto mb-8">Purchase WorkInPrivate to get instant download access for Windows, macOS, and Linux.</p>
-      <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
+      <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, checkout_source: 'download_page', items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
         Buy Now — $14.99
       </a>
       <p class="text-[#8A9AB5] text-sm mt-4">One-time payment. Download links provided immediately after purchase.</p>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -68,7 +68,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </li>
             </ul>
 
-            <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
+            <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, checkout_source: 'pricing_page', items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="block w-full text-center px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
               Buy Now — $14.99
             </a>
 


### PR DESCRIPTION
## Problem
The `/download` page's "Buy Now" button was a plain link with **no `begin_checkout` event**, while the `/pricing` button fired one. Any checkout intent originating from the download page (e.g. ad traffic landing there) was therefore **invisible in the GA funnel**, making conversion look worse than reality.

## Changes
- **`download.astro`** — add the `begin_checkout` GA event to the Buy Now button, matching the pricing page.
- **Both buttons** — add a `checkout_source` parameter (`download_page` / `pricing_page`) so the two entry points can be compared in GA.

`npm run build` passes (12 pages built).

## Not covered by this PR (Stripe config — needs manual verification)
The `purchase` event only fires if the Stripe Payment Link redirects back to `/purchase-success?session_id={CHECKOUT_SESSION_ID}`. Verify the **new** Payment Link's confirmation page is set to that URL **with "include session ID" enabled**, or real sales won't register as `purchase` in GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrWA4cj3NqqX7pXiWMUdEr)_