### PR TITLE
Recenter site messaging on "the easiest local AI for normal people"

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const {
   title,
-  description = 'WorkInPrivate - Secure, private work environment for professionals',
+  description = 'WorkInPrivate — the easiest local AI for normal people. Private AI that runs on your own computer. No cloud, no accounts, no confusing setup.',
   ogImage = '/og-image.png'
 } = Astro.props;
 
@@ -98,7 +98,7 @@ const isPreview = import.meta.env.PUBLIC_SITE_PREVIEW !== 'false';
       "@type": "WebSite",
       "name": "WorkInPrivate",
       "url": siteUrl,
-      "description": "Your private AI chatbot — runs 100% on your computer. No cloud. No accounts. Just you.",
+      "description": "The easiest local AI for normal people — runs on your own computer. No cloud. No accounts. No confusing setup.",
       "publisher": {
         "@type": "Organization",
         "name": "Wallco Digital Labs LLC"

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -8,7 +8,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="py-16 sm:py-20 bg-gradient-to-b from-white to-[#F7F9FC]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h1 class="font-serif text-4xl sm:text-5xl font-bold text-[#1B3A5C] mb-4">Download WorkInPrivate</h1>
-      <p class="text-xl text-[#5A6474] max-w-2xl mx-auto mb-8">Purchase WorkInPrivate to get instant download access for Windows, macOS, and Linux.</p>
+      <p class="text-xl text-[#5A6474] max-w-2xl mx-auto mb-8">Get instant download access for Windows, macOS, and Linux. Install it like any other app, let the guided setup check your computer, and start chatting privately.</p>
       <a href="https://buy.stripe.com/4gM4gzb7LehO52Le5TaR20p" onclick="gtag('event', 'begin_checkout', {currency: 'USD', value: 14.99, checkout_source: 'download_page', items: [{item_id: 'workinprivate', item_name: 'WorkInPrivate', price: 14.99, quantity: 1}]});" class="inline-flex items-center gap-2 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
         Buy Now — $14.99
       </a>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -19,6 +19,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       },
       {
         "@type": "Question",
+        "name": "What does \"local AI\" mean?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Local AI means the AI runs directly on your own computer instead of on a company's servers somewhere on the internet. Tools like ChatGPT send everything you type to the cloud. With local AI, your questions, documents, and files stay on your machine — nothing is sent away. WorkInPrivate handles all the technical setup so you get local AI without needing to understand how it works."
+        }
+      },
+      {
+        "@type": "Question",
         "name": "How is this different from ChatGPT?",
         "acceptedAnswer": {
           "@type": "Answer",
@@ -105,6 +113,16 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </summary>
           <div class="px-6 pb-5 text-[#5A6474] text-sm leading-relaxed">
             WorkInPrivate is a private AI chatbot — like ChatGPT, but it runs entirely on your computer. You can chat with it, ask questions, write emails, brainstorm ideas, analyze documents, and more. Everything stays on your machine. Nothing is sent to the cloud.
+          </div>
+        </details>
+
+        <details class="group bg-[#F7F9FC] border-2 border-[#E2E8F0] rounded-xl overflow-hidden hover:border-[#D4E3F5] transition-colors">
+          <summary class="flex items-center justify-between cursor-pointer px-6 py-5 font-bold text-[#1B3A5C] text-base">
+            What does "local AI" mean?
+            <svg class="w-5 h-5 text-[#4B8BD4] group-open:rotate-180 transition-transform flex-shrink-0 ml-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6,9 12,15 18,9"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-[#5A6474] text-sm leading-relaxed">
+            Local AI means the AI runs directly on your own computer instead of on a company's servers somewhere on the internet. Tools like ChatGPT send everything you type to the cloud. With local AI, your questions, documents, and files stay on your machine — nothing is sent away. WorkInPrivate handles all the technical setup so you get local AI without needing to understand how it works.
           </div>
         </details>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,14 +2,14 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="WorkInPrivate — Your Private AI Chatbot" description="WorkInPrivate is a private AI chatbot that runs 100% on your computer. No cloud, no accounts, no data leaves your machine. Chat, analyze files, and get AI help — all locally.">
+<BaseLayout title="WorkInPrivate — The Easiest Local AI for Normal People" description="WorkInPrivate is private AI that runs on your own computer. No cloud account, no confusing setup, no sending your files to someone else's server. The easy, friendly way to use local AI.">
 
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "WorkInPrivate",
-    "description": "A private AI chatbot that runs entirely on your computer. No cloud, no accounts, no data leaves your machine.",
+    "description": "The easiest local AI for normal people. A ChatGPT-like assistant that runs on your own computer — no cloud account, no confusing setup, no data leaving your machine.",
     "url": "https://www.workinprivate.com",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "Windows, macOS, Linux",
@@ -20,11 +20,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       "availability": "https://schema.org/InStock"
     },
     "featureList": [
-      "Runs 100% on your computer",
+      "Runs on your own computer — not the cloud",
       "Chat with AI like ChatGPT — but private",
-      "Analyze documents and images locally",
+      "Guided setup that checks your computer for you",
+      "No accounts, no command line, no jargon",
       "One-time purchase — no subscription",
-      "Works offline after setup",
       "Works on Windows, macOS, and Linux"
     ]
   })} />
@@ -40,10 +40,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             100% private — nothing leaves your computer
           </div>
           <h1 class="font-serif text-4xl sm:text-5xl font-bold text-[#1B3A5C] mb-5 leading-tight" style="animation: fadeUp 0.5s ease 0.1s both;">
-            Your Private AI Chatbot.<br /><span class="text-[#4B8BD4]">No Cloud. No Accounts.</span>
+            The Easiest Local AI<br /><span class="text-[#4B8BD4]">for Normal People.</span>
           </h1>
           <p class="text-lg text-[#5A6474] mb-8 max-w-lg leading-relaxed" style="animation: fadeUp 0.5s ease 0.2s both;">
-            WorkInPrivate is a ChatGPT-like AI that runs entirely on your computer. Chat, write, analyze documents, and get AI help — without any of your data ever leaving your machine.
+            WorkInPrivate gives you a ChatGPT-like assistant that runs on your own computer. No cloud account. No confusing setup. No sending private files to someone else's server.
           </p>
           <div class="flex flex-wrap gap-4 mb-7" style="animation: fadeUp 0.5s ease 0.3s both;">
             <a href="/pricing" class="inline-flex items-center gap-2.5 px-8 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
@@ -101,17 +101,61 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="py-20 bg-[#EDF2FA] border-t-2 border-b-2 border-[#D4E3F5]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-3xl mx-auto text-center">
-        <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">What Is This?</div>
-        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5 leading-tight">Like ChatGPT, But On Your Computer</h2>
+        <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">What Is Local AI?</div>
+        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5 leading-tight">AI That Runs On Your Computer, Not The Cloud</h2>
+        <p class="text-lg text-[#5A6474] leading-relaxed mb-4">
+          Most AI tools, like ChatGPT, send everything you type to a company's servers over the internet. "Local AI" is different: the AI lives and runs right on your own computer. Your questions, your documents, and your files stay with you — there's no server to send them to.
+        </p>
         <p class="text-lg text-[#5A6474] leading-relaxed">
-          You've probably used ChatGPT or Claude. They're great, but they cost $20+ per month and send everything you type to the cloud. WorkInPrivate gives you the same chat experience, but everything runs right on your computer. Pay once ($14.99), and it's yours forever. No monthly bills. No data collection. No one reading your conversations.
+          WorkInPrivate gives you that same chat experience without the cloud. Pay once ($14.99) and it's yours forever. No monthly bills. No data collection. No one reading your conversations.
         </p>
       </div>
     </div>
   </section>
 
+  <!-- Built For Normal People Section -->
+  <section class="py-20 bg-white">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-5xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+        <div>
+          <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">Built For Normal People</div>
+          <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5 leading-tight">No AI Hobbyist Degree Required</h2>
+          <p class="text-lg text-[#5A6474] leading-relaxed mb-4">
+            Running AI on your own computer usually means wrestling with terminals, model files, and settings that assume you already know what a "GPU" or a "quantization" is. That's fine for hobbyists. It's miserable for everyone else.
+          </p>
+          <p class="text-lg text-[#5A6474] leading-relaxed">
+            WorkInPrivate does the technical part for you. It checks your computer, picks an AI that will run well on it, and sets everything up behind a friendly window — no command line, no config files, no guesswork. You just open it and start typing.
+          </p>
+        </div>
+        <div class="space-y-4">
+          <div class="flex items-start gap-4 bg-[#F0FFF4] border-2 border-[#C6F6D5] rounded-xl p-5">
+            <svg class="w-6 h-6 text-[#38A169] flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
+            <div>
+              <h3 class="font-bold text-[#1B3A5C] text-base mb-1">It picks the right AI for you</h3>
+              <p class="text-[#5A6474] text-sm leading-relaxed">No comparing model names or specs. WorkInPrivate looks at your computer and recommends one that fits.</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-4 bg-[#F0FFF4] border-2 border-[#C6F6D5] rounded-xl p-5">
+            <svg class="w-6 h-6 text-[#38A169] flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
+            <div>
+              <h3 class="font-bold text-[#1B3A5C] text-base mb-1">No command line, ever</h3>
+              <p class="text-[#5A6474] text-sm leading-relaxed">Everything happens in a normal app window with buttons you can actually understand.</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-4 bg-[#F0FFF4] border-2 border-[#C6F6D5] rounded-xl p-5">
+            <svg class="w-6 h-6 text-[#38A169] flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
+            <div>
+              <h3 class="font-bold text-[#1B3A5C] text-base mb-1">If you can text, you can use it</h3>
+              <p class="text-[#5A6474] text-sm leading-relaxed">It works like any chat app you already know. Type a message, get an answer.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- How It Works Section -->
-  <section id="how-it-works" class="py-20 bg-white">
+  <section id="how-it-works" class="py-20 bg-[#F7F9FC] border-t-2 border-[#E2E8F0]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-4">
         <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">How It Works</div>
@@ -125,8 +169,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <svg class="w-7 h-7 text-[#4B8BD4]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           </div>
           <div class="text-xs font-bold uppercase tracking-wider text-[#4B8BD4] mb-2.5">Step 1</div>
-          <h3 class="font-serif text-lg font-bold text-[#1B3A5C] mb-3">Download & Open</h3>
-          <p class="text-[#5A6474] text-base leading-relaxed">Download WorkInPrivate and double-click to open. A friendly setup wizard walks you through choosing an AI model that works best for your computer.</p>
+          <h3 class="font-serif text-lg font-bold text-[#1B3A5C] mb-3">Install WorkInPrivate</h3>
+          <p class="text-[#5A6474] text-base leading-relaxed">Download the app and double-click to open it — just like installing any other program. No accounts to create, nothing to configure.</p>
         </div>
         <!-- Step 2 -->
         <div class="bg-[#F7F9FC] border-2 border-[#E2E8F0] rounded-2xl p-9 text-center hover:border-[#D4E3F5] transition-all">
@@ -134,8 +178,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <svg class="w-7 h-7 text-[#4B8BD4]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
           </div>
           <div class="text-xs font-bold uppercase tracking-wider text-[#4B8BD4] mb-2.5">Step 2</div>
-          <h3 class="font-serif text-lg font-bold text-[#1B3A5C] mb-3">Start Chatting</h3>
-          <p class="text-[#5A6474] text-base leading-relaxed">Type anything — ask questions, write emails, brainstorm ideas, analyze documents. Just like ChatGPT, but completely private.</p>
+          <h3 class="font-serif text-lg font-bold text-[#1B3A5C] mb-3">Let It Check Your Computer</h3>
+          <p class="text-[#5A6474] text-base leading-relaxed">WorkInPrivate looks at your computer and sets up an AI that will run well on it. The guided setup handles the technical parts so you don't have to.</p>
         </div>
         <!-- Step 3 -->
         <div class="bg-[#F7F9FC] border-2 border-[#E2E8F0] rounded-2xl p-9 text-center hover:border-[#D4E3F5] transition-all">
@@ -143,19 +187,20 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <svg class="w-7 h-7 text-[#4B8BD4]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
           </div>
           <div class="text-xs font-bold uppercase tracking-wider text-[#4B8BD4] mb-2.5">Step 3</div>
-          <h3 class="font-serif text-lg font-bold text-[#1B3A5C] mb-3">Stay Private</h3>
-          <p class="text-[#5A6474] text-base leading-relaxed">Everything you type stays on your machine. No internet connection needed after setup. Your conversations are yours alone — forever.</p>
+          <h3 class="font-serif text-lg font-bold text-[#1B3A5C] mb-3">Start Chatting Privately</h3>
+          <p class="text-[#5A6474] text-base leading-relaxed">Ask questions, write emails, brainstorm, or analyze documents — just like ChatGPT. Everything you type stays on your machine, and it works without an internet connection.</p>
         </div>
       </div>
     </div>
   </section>
 
   <!-- Features Section -->
-  <section class="py-20 bg-[#F7F9FC] border-t-2 border-[#E2E8F0]">
+  <section class="py-20 bg-white border-t-2 border-[#E2E8F0]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12">
         <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">Features</div>
-        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] leading-tight">Everything You Need</h2>
+        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-4 leading-tight">Everything You Need, Nothing You Don't</h2>
+        <p class="text-lg text-[#5A6474] max-w-lg mx-auto">All the everyday AI help you'd expect — kept completely private and simple to use.</p>
       </div>
       <div class="max-w-5xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-white border-2 border-[#E2E8F0] rounded-xl p-7 flex gap-4 hover:border-[#D4E3F5] transition-colors">
@@ -208,8 +253,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <svg class="w-6 h-6 text-[#38A169]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           </div>
           <div>
-            <h3 class="font-bold text-[#1B3A5C] text-base mb-1">Smart Setup</h3>
-            <p class="text-[#5A6474] text-sm leading-relaxed">The app detects your hardware and recommends the best AI model for your computer. No technical knowledge needed.</p>
+            <h3 class="font-bold text-[#1B3A5C] text-base mb-1">Guided Setup</h3>
+            <p class="text-[#5A6474] text-sm leading-relaxed">WorkInPrivate checks your computer and picks an AI that runs well on it — so you never have to compare models or touch a command line.</p>
           </div>
         </div>
       </div>
@@ -217,7 +262,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </section>
 
   <!-- Comparison Section -->
-  <section class="py-20 bg-white border-t-2 border-[#E2E8F0]">
+  <section class="py-20 bg-[#F7F9FC] border-t-2 border-[#E2E8F0]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12">
         <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">Compare</div>
@@ -280,13 +325,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
   </section>
 
-  <!-- Privacy Section -->
+  <!-- Why Private Section -->
   <section class="py-20 bg-[#EDF2FA] border-t-2 border-[#D4E3F5]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12">
-        <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">Privacy</div>
-        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-4 leading-tight">Your Conversations Stay Private</h2>
-        <p class="text-[#5A6474] text-lg max-w-xl mx-auto">No one is watching — not during setup, not while you chat, not ever.</p>
+        <div class="text-xs font-bold uppercase tracking-widest text-[#4B8BD4] mb-3">Why Private?</div>
+        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-4 leading-tight">Some Things Shouldn't Leave Your Computer</h2>
+        <p class="text-[#5A6474] text-lg max-w-2xl mx-auto">A lot of what we'd ask an AI is personal. With WorkInPrivate, it stays that way — your personal documents, work files, finances, family details, half-formed ideas, and sensitive writing never touch someone else's server.</p>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-5xl mx-auto">
         <div class="bg-white border-2 border-[#E2E8F0] rounded-2xl p-8 hover:border-[#D4E3F5] transition-colors">
@@ -318,8 +363,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="py-20 bg-white border-t-2 border-[#E2E8F0]">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-2xl mx-auto text-center">
-        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5">Ready for a Private AI?</h2>
-        <p class="text-lg text-[#5A6474] mb-8">Stop paying monthly subscriptions. Stop sending your data to the cloud. Get WorkInPrivate and own your AI experience.</p>
+        <h2 class="font-serif text-3xl sm:text-4xl font-bold text-[#1B3A5C] mb-5">Try Local AI The Easy Way</h2>
+        <p class="text-lg text-[#5A6474] mb-8">No subscriptions. No cloud. No setup headaches. Just private AI that runs on your computer — and a guided setup that does the technical part for you.</p>
         <a href="/pricing" class="inline-flex items-center gap-2.5 px-10 py-4 rounded-[10px] text-white font-bold text-lg bg-[#4B8BD4] hover:bg-[#2E6BB5] transition-all no-underline" style="text-decoration: none; box-shadow: 0 2px 8px rgba(75,139,212,0.3);">
           Buy Now — $14.99
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -24,7 +24,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <!-- Card Header -->
           <div class="bg-[#4B8BD4] px-8 py-8 text-center text-white">
             <h2 class="font-serif text-2xl font-bold mb-2">WorkInPrivate</h2>
-            <p class="text-[#D4E3F5] text-sm">Your private AI chatbot</p>
+            <p class="text-[#D4E3F5] text-sm">The easiest local AI for normal people</p>
             <div class="mt-4">
               <span class="text-5xl font-bold">$14.99</span>
               <span class="text-[#D4E3F5] text-lg ml-2">one-time</span>
@@ -48,7 +48,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               </li>
               <li class="flex items-start gap-3">
                 <svg class="w-5 h-5 text-[#38A169] flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
-                <span class="text-[#1B3A5C]"><strong>Multiple AI models</strong> — choose the best for your needs</span>
+                <span class="text-[#1B3A5C]"><strong>Guided setup</strong> — it picks an AI that fits your computer</span>
               </li>
               <li class="flex items-start gap-3">
                 <svg class="w-5 h-5 text-[#38A169] flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>


### PR DESCRIPTION
Refocuses the marketing copy toward everyday, non-technical users who want private AI without understanding models, GPUs, terminals, or setup.

## Highlights

- **Hero**: new headline **"The Easiest Local AI for Normal People"** with plain-English subcopy (no cloud account, no confusing setup, no sending files to someone else's server).
- **"What is local AI?"**: reworked the old "What Is This?" block into a plain-English explainer — the AI runs on your computer instead of a company's servers.
- **"Built for normal people" (new section)**: carries the "No AI hobbyist degree required" framing — no command line, picks the right AI for you, if you can text you can use it.
- **How It Works**: steps rewritten to Install → Let it check your computer → Start chatting privately.
- **"Why private?"**: reframed Privacy section around everyday stakes (personal docs, work files, finances, family info, ideas, sensitive writing).
- **Smaller touches**: softened feature copy ("Guided Setup"), CTA, pricing card subtitle, download intro, meta/JSON-LD descriptions, and added a "What does local AI mean?" FAQ entry (page + structured data).

## Notes
- Purchase CTAs keep "Buy Now — $14.99" for price clarity; friendlier framing used on soft CTAs/headers.
- Existing ChatGPT/Claude comparison table left intact; no new competitor names introduced.
- No new features invented — all copy maps to existing capabilities. Design structure preserved aside from the new two-column section and section background swaps to keep alternation correct.
- `npm run build` passes.

## Files
- `src/pages/index.astro`
- `src/pages/faq.astro`
- `src/pages/pricing.astro`
- `src/pages/download.astro`
- `src/layouts/BaseLayout.astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013C5ztDWSuXoYNwZVW365Px)_